### PR TITLE
feat(ai-service): generation endpoints for Session B (test + artifacts)

### DIFF
--- a/packages/core/python/src/application/dto/generate.py
+++ b/packages/core/python/src/application/dto/generate.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class GenerateTestRequest(BaseModel):
+    exploration_report: dict[str, object] = Field(description="Report from Session A exploration")
+    failure_report: dict[str, object] | None = Field(default=None, description="Previous failure report if retrying")
+    model: str = Field(default="", description="LLM model override (empty = use default)")
+
+
+class GenerateTestResponse(BaseModel):
+    code: str
+    tokens_used: int
+
+
+class GenerateArtifactsRequest(BaseModel):
+    model: str = Field(default="", description="LLM model override (empty = use default)")
+
+
+class GenerateArtifactsResponse(BaseModel):
+    pom_md: str
+    gherkin_md: str
+    cucumber_md: str
+    tokens_used: int

--- a/packages/core/python/src/application/use_cases/generate/generate_artifacts_use_case.py
+++ b/packages/core/python/src/application/use_cases/generate/generate_artifacts_use_case.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from src.application.dto.generate import GenerateArtifactsResponse
+from src.domain.model.session import Session
+from src.domain.repository.llm_service import LlmService
+from src.infrastructure.prompts.artifacts_prompt import (
+    ARTIFACTS_SYSTEM_PROMPT,
+    build_artifacts_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GenerateArtifactsUseCase:
+    def __init__(self, llm_service: LlmService) -> None:
+        self._llm_service = llm_service
+
+    async def execute(self, session: Session) -> GenerateArtifactsResponse:
+        prompt = build_artifacts_prompt()
+        session.add_message("user", prompt)
+
+        raw_response, _cost = await self._llm_service.generate_with_history(
+            messages=session.history,
+            system_prompt=ARTIFACTS_SYSTEM_PROMPT,
+        )
+
+        session.add_message("assistant", raw_response)
+        tokens_used = await self._llm_service.count_tokens(prompt)
+        parsed = self._parse_response(raw_response)
+
+        return GenerateArtifactsResponse(
+            pom_md=str(parsed.get("pom_md", "")),
+            gherkin_md=str(parsed.get("gherkin_md", "")),
+            cucumber_md=str(parsed.get("cucumber_md", "")),
+            tokens_used=tokens_used,
+        )
+
+    @staticmethod
+    def _parse_response(raw: str) -> dict[str, object]:
+        cleaned = raw.strip()
+        if cleaned.startswith("```"):
+            lines = cleaned.split("\n")
+            cleaned = "\n".join(lines[1:-1])
+        try:
+            result: dict[str, object] = json.loads(cleaned)
+            return result
+        except json.JSONDecodeError:
+            logger.error("Failed to parse artifacts response as JSON: %s", cleaned[:200])
+            return {}

--- a/packages/core/python/src/application/use_cases/generate/generate_test_use_case.py
+++ b/packages/core/python/src/application/use_cases/generate/generate_test_use_case.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+
+from src.application.dto.generate import GenerateTestRequest, GenerateTestResponse
+from src.domain.model.session import Session
+from src.domain.repository.llm_service import LlmService
+from src.infrastructure.prompts.generation_prompt import (
+    GENERATION_SYSTEM_PROMPT,
+    build_generation_prompt,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GenerateTestUseCase:
+    def __init__(self, llm_service: LlmService) -> None:
+        self._llm_service = llm_service
+
+    async def execute(self, session: Session, request: GenerateTestRequest) -> GenerateTestResponse:
+        prompt = build_generation_prompt(request.exploration_report, request.failure_report)
+        session.add_message("user", prompt)
+
+        raw_response, _cost = await self._llm_service.generate_with_history(
+            messages=session.history,
+            system_prompt=GENERATION_SYSTEM_PROMPT,
+        )
+
+        session.add_message("assistant", raw_response)
+        tokens_used = await self._llm_service.count_tokens(prompt)
+
+        code = self._clean_code(raw_response)
+        return GenerateTestResponse(code=code, tokens_used=tokens_used)
+
+    @staticmethod
+    def _clean_code(raw: str) -> str:
+        cleaned = raw.strip()
+        if cleaned.startswith("```"):
+            lines = cleaned.split("\n")
+            cleaned = "\n".join(lines[1:-1])
+        return cleaned

--- a/packages/core/python/src/infrastructure/prompts/artifacts_prompt.py
+++ b/packages/core/python/src/infrastructure/prompts/artifacts_prompt.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+ARTIFACTS_SYSTEM_PROMPT = """\
+You are an expert test automation engineer. Based on the test code generated in this conversation, \
+produce three artifacts. You MUST respond with valid JSON only:
+
+{
+  "pom_md": "Page Object Model documentation in markdown",
+  "gherkin_md": "Gherkin feature file content in markdown",
+  "cucumber_md": "Cucumber step definitions in markdown"
+}
+
+Rules for each artifact:
+
+**pom_md**: Document each Page Object with:
+- Class name and target page/URL
+- Selectors (name, strategy, value)
+- Actions/methods available
+
+**gherkin_md**: Write a .feature file with:
+- Feature name and description
+- Scenario(s) using Given/When/Then
+- Use parameters where applicable
+
+**cucumber_md**: Write step definitions that:
+- Map to the Gherkin steps
+- Reference the Page Objects
+- Include TypeScript Playwright implementations
+
+Do NOT wrap the JSON in markdown code blocks — return raw JSON only.\
+"""
+
+
+def build_artifacts_prompt() -> str:
+    return (
+        "Based on the test generated in this conversation, "
+        "produce the POM documentation, Gherkin feature, and Cucumber step definitions."
+    )

--- a/packages/core/python/src/infrastructure/prompts/generation_prompt.py
+++ b/packages/core/python/src/infrastructure/prompts/generation_prompt.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+GENERATION_SYSTEM_PROMPT = """\
+You are an expert Playwright test engineer. Generate a complete, runnable .spec.ts test file.
+
+Rules:
+- Use TypeScript with Playwright's test runner (`import { test, expect } from '@playwright/test'`)
+- Follow Page Object Model pattern where applicable
+- Use data-testid selectors when available, fall back to role/text/CSS
+- Include proper assertions for each step
+- Handle async/await correctly
+- Add descriptive test.describe and test blocks
+- Do NOT wrap the output in markdown code blocks — return raw TypeScript only\
+"""
+
+GENERATION_WITH_FAILURE_PROMPT = """\
+The previous test attempt FAILED. Below is the failure report.
+You MUST fix the issues described and generate a corrected test.
+Do NOT repeat the same mistakes. Analyze the failure and adapt your approach.
+
+Failure report:
+{failure_report}\
+"""
+
+
+def build_generation_prompt(
+    exploration_report: dict[str, object],
+    failure_report: dict[str, object] | None = None,
+) -> str:
+    parts = [
+        "Generate a Playwright .spec.ts test based on this exploration report:",
+        json.dumps(exploration_report, indent=2),
+    ]
+    if failure_report:
+        parts.append(GENERATION_WITH_FAILURE_PROMPT.format(failure_report=json.dumps(failure_report, indent=2)))
+    return "\n\n".join(parts)

--- a/packages/core/python/src/server.py
+++ b/packages/core/python/src/server.py
@@ -6,8 +6,16 @@ from src.application.dto.explore import (
     ExploreRequest,
     ExploreResponse,
 )
+from src.application.dto.generate import (
+    GenerateArtifactsRequest,
+    GenerateArtifactsResponse,
+    GenerateTestRequest,
+    GenerateTestResponse,
+)
 from src.application.dto.prepare_input import PrepareInputRequest, PrepareInputResponse
 from src.application.use_cases.explore.explore_use_case import ExploreUseCase
+from src.application.use_cases.generate.generate_artifacts_use_case import GenerateArtifactsUseCase
+from src.application.use_cases.generate.generate_test_use_case import GenerateTestUseCase
 from src.application.use_cases.prepare_input.prepare_input_use_case import PrepareInputUseCase
 from src.infrastructure.config.dependency_injection import get_container
 
@@ -52,3 +60,25 @@ async def explore(session_id: str, request: ExploreRequest) -> ExploreResponse:
     llm_service = container.get_llm_service(model_override=request.model)
     use_case = ExploreUseCase(llm_service)
     return await use_case.execute(session, request.html, request.context)
+
+
+@app.post("/session/{session_id}/generate-test")
+async def generate_test(session_id: str, request: GenerateTestRequest) -> GenerateTestResponse:
+    container = get_container()
+    session = container.get_session_store().get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    llm_service = container.get_llm_service(model_override=request.model)
+    use_case = GenerateTestUseCase(llm_service)
+    return await use_case.execute(session, request)
+
+
+@app.post("/session/{session_id}/generate-artifacts")
+async def generate_artifacts(session_id: str, request: GenerateArtifactsRequest) -> GenerateArtifactsResponse:
+    container = get_container()
+    session = container.get_session_store().get(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    llm_service = container.get_llm_service(model_override=request.model)
+    use_case = GenerateArtifactsUseCase(llm_service)
+    return await use_case.execute(session)

--- a/packages/core/python/tests/application/test_generate.py
+++ b/packages/core/python/tests/application/test_generate.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.application.dto.generate import GenerateTestRequest
+from src.application.use_cases.generate.generate_artifacts_use_case import GenerateArtifactsUseCase
+from src.application.use_cases.generate.generate_test_use_case import GenerateTestUseCase
+from src.domain.model.session import Session
+
+
+def _mock_llm(response: str) -> AsyncMock:
+    service = AsyncMock()
+    service.generate_with_history.return_value = (response, 0.01)
+    service.count_tokens.return_value = 200
+    return service
+
+
+class TestGenerateTestUseCase:
+    @pytest.mark.asyncio
+    async def test_generates_test_code(self) -> None:
+        code = 'import { test, expect } from "@playwright/test";\ntest("login", async ({ page }) => {});'
+        service = _mock_llm(code)
+        session = Session()
+        use_case = GenerateTestUseCase(service)
+
+        request = GenerateTestRequest(exploration_report={"url": "https://example.com", "actions": ["click login"]})
+        result = await use_case.execute(session, request)
+
+        assert "playwright/test" in result.code
+        assert result.tokens_used == 200
+
+    @pytest.mark.asyncio
+    async def test_cleans_markdown_code_blocks(self) -> None:
+        raw = '```typescript\nimport { test } from "@playwright/test";\n```'
+        service = _mock_llm(raw)
+        session = Session()
+        use_case = GenerateTestUseCase(service)
+
+        request = GenerateTestRequest(exploration_report={"url": "https://example.com"})
+        result = await use_case.execute(session, request)
+
+        assert not result.code.startswith("```")
+        assert "import { test }" in result.code
+
+    @pytest.mark.asyncio
+    async def test_with_failure_report(self) -> None:
+        service = _mock_llm("fixed test code")
+        session = Session()
+        use_case = GenerateTestUseCase(service)
+
+        request = GenerateTestRequest(
+            exploration_report={"url": "https://example.com"},
+            failure_report={"error": "timeout on login button", "line": 15},
+        )
+        result = await use_case.execute(session, request)
+
+        # Verify the prompt includes failure context
+        call_messages = service.generate_with_history.call_args.kwargs["messages"]
+        prompt_text = call_messages[0]["content"]
+        assert "FAILED" in prompt_text
+        assert "timeout on login button" in prompt_text
+        assert result.code == "fixed test code"
+
+    @pytest.mark.asyncio
+    async def test_accumulates_in_session(self) -> None:
+        service = _mock_llm("test code")
+        session = Session()
+        use_case = GenerateTestUseCase(service)
+
+        request = GenerateTestRequest(exploration_report={"url": "https://example.com"})
+        await use_case.execute(session, request)
+
+        assert len(session.history) == 2  # user prompt + assistant response
+
+
+class TestGenerateArtifactsUseCase:
+    @pytest.mark.asyncio
+    async def test_generates_artifacts(self) -> None:
+        artifacts = {
+            "pom_md": "# LoginPage\n- selector: [data-testid=login]",
+            "gherkin_md": "Feature: Login\n  Scenario: Valid login",
+            "cucumber_md": "Given('user is on login page', ...)",
+        }
+        service = _mock_llm(json.dumps(artifacts))
+        session = Session()
+        session.add_message("user", "generate test")
+        session.add_message("assistant", "test code here")
+        use_case = GenerateArtifactsUseCase(service)
+
+        result = await use_case.execute(session)
+
+        assert "LoginPage" in result.pom_md
+        assert "Feature: Login" in result.gherkin_md
+        assert "Given" in result.cucumber_md
+
+    @pytest.mark.asyncio
+    async def test_continues_session_history(self) -> None:
+        service = _mock_llm(json.dumps({"pom_md": "", "gherkin_md": "", "cucumber_md": ""}))
+        session = Session()
+        session.add_message("user", "prev prompt")
+        session.add_message("assistant", "prev response")
+        use_case = GenerateArtifactsUseCase(service)
+
+        await use_case.execute(session)
+
+        # 2 previous + 2 new (user + assistant)
+        assert len(session.history) == 4
+        call_messages = service.generate_with_history.call_args.kwargs["messages"]
+        assert len(call_messages) == 4


### PR DESCRIPTION
## Summary
- `POST /session/{id}/generate-test`: genera `.spec.ts` desde exploration_report, soporta failure_report para reintentos
- `POST /session/{id}/generate-artifacts`: genera POM, Gherkin y Cucumber en la misma sesión (el LLM ya tiene contexto del test)
- Prompts dedicados: generation_prompt (test) y artifacts_prompt (POM/Gherkin/Cucumber)
- DTOs Pydantic para request/response
- Ambos use cases acumulan en el historial de sesión B

## QA
- `ruff check` ✅
- `mypy --strict` ✅
- `pytest` 34/34 ✅ (6 nuevos: 4 generate-test + 2 generate-artifacts)

## Test plan
- [x] Genera código .spec.ts válido desde exploration_report
- [x] Limpia markdown code blocks del output
- [x] Con failure_report: el prompt incluye contexto del fallo anterior
- [x] generate-test acumula historial en sesión
- [x] generate-artifacts continúa la sesión con el contexto completo del test
- [x] generate-artifacts recibe historial completo (previo + nuevo)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)