### PR TITLE
refactor(ai-service): fix selector priority and extract shared parser

### DIFF
--- a/packages/core/python/src/application/shared/llm_response_parser.py
+++ b/packages/core/python/src/application/shared/llm_response_parser.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def parse_llm_json(raw: str, context: str = "LLM") -> dict[str, object]:
+    """Parse a JSON response from an LLM, stripping markdown code blocks if present."""
+    cleaned = raw.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        cleaned = "\n".join(lines[1:-1])
+    try:
+        result: dict[str, object] = json.loads(cleaned)
+        return result
+    except json.JSONDecodeError:
+        logger.error("Failed to parse %s response as JSON: %s", context, cleaned[:200])
+        return {}
+
+
+def clean_code_block(raw: str) -> str:
+    """Strip markdown code block wrappers from LLM output."""
+    cleaned = raw.strip()
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        cleaned = "\n".join(lines[1:-1])
+    return cleaned

--- a/packages/core/python/src/application/use_cases/explore/explore_use_case.py
+++ b/packages/core/python/src/application/use_cases/explore/explore_use_case.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-import json
-import logging
-
 from src.application.dto.explore import ExploreResponse
+from src.application.shared.llm_response_parser import parse_llm_json
 from src.domain.model.session import Session
 from src.domain.repository.llm_service import LlmService
 from src.infrastructure.prompts.exploration_prompt import (
     EXPLORATION_SYSTEM_PROMPT,
     build_exploration_prompt,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class ExploreUseCase:
@@ -34,7 +30,7 @@ class ExploreUseCase:
 
         session.add_message("assistant", raw_response)
         tokens_used = await self._llm_service.count_tokens(user_prompt)
-        parsed = self._parse_llm_response(raw_response)
+        parsed = parse_llm_json(raw_response, context="explore")
 
         completed = bool(parsed.get("completed", False))
         if completed:
@@ -48,19 +44,6 @@ class ExploreUseCase:
             analysis_summary=str(parsed.get("analysis_summary", "")),
             tokens_used=tokens_used,
         )
-
-    @staticmethod
-    def _parse_llm_response(raw: str) -> dict[str, object]:
-        cleaned = raw.strip()
-        if cleaned.startswith("```"):
-            lines = cleaned.split("\n")
-            cleaned = "\n".join(lines[1:-1])
-        try:
-            result: dict[str, object] = json.loads(cleaned)
-            return result
-        except json.JSONDecodeError:
-            logger.error("Failed to parse explore response as JSON: %s", cleaned[:200])
-            return {}
 
     @staticmethod
     def _extract_value(raw: object) -> str | None:

--- a/packages/core/python/src/application/use_cases/generate/generate_artifacts_use_case.py
+++ b/packages/core/python/src/application/use_cases/generate/generate_artifacts_use_case.py
@@ -1,17 +1,13 @@
 from __future__ import annotations
 
-import json
-import logging
-
 from src.application.dto.generate import GenerateArtifactsResponse
+from src.application.shared.llm_response_parser import parse_llm_json
 from src.domain.model.session import Session
 from src.domain.repository.llm_service import LlmService
 from src.infrastructure.prompts.artifacts_prompt import (
     ARTIFACTS_SYSTEM_PROMPT,
     build_artifacts_prompt,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class GenerateArtifactsUseCase:
@@ -29,7 +25,7 @@ class GenerateArtifactsUseCase:
 
         session.add_message("assistant", raw_response)
         tokens_used = await self._llm_service.count_tokens(prompt)
-        parsed = self._parse_response(raw_response)
+        parsed = parse_llm_json(raw_response, context="artifacts")
 
         return GenerateArtifactsResponse(
             pom_md=str(parsed.get("pom_md", "")),
@@ -37,16 +33,3 @@ class GenerateArtifactsUseCase:
             cucumber_md=str(parsed.get("cucumber_md", "")),
             tokens_used=tokens_used,
         )
-
-    @staticmethod
-    def _parse_response(raw: str) -> dict[str, object]:
-        cleaned = raw.strip()
-        if cleaned.startswith("```"):
-            lines = cleaned.split("\n")
-            cleaned = "\n".join(lines[1:-1])
-        try:
-            result: dict[str, object] = json.loads(cleaned)
-            return result
-        except json.JSONDecodeError:
-            logger.error("Failed to parse artifacts response as JSON: %s", cleaned[:200])
-            return {}

--- a/packages/core/python/src/application/use_cases/generate/generate_test_use_case.py
+++ b/packages/core/python/src/application/use_cases/generate/generate_test_use_case.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-import logging
-
 from src.application.dto.generate import GenerateTestRequest, GenerateTestResponse
+from src.application.shared.llm_response_parser import clean_code_block
 from src.domain.model.session import Session
 from src.domain.repository.llm_service import LlmService
 from src.infrastructure.prompts.generation_prompt import (
     GENERATION_SYSTEM_PROMPT,
     build_generation_prompt,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class GenerateTestUseCase:
@@ -29,13 +26,5 @@ class GenerateTestUseCase:
         session.add_message("assistant", raw_response)
         tokens_used = await self._llm_service.count_tokens(prompt)
 
-        code = self._clean_code(raw_response)
+        code = clean_code_block(raw_response)
         return GenerateTestResponse(code=code, tokens_used=tokens_used)
-
-    @staticmethod
-    def _clean_code(raw: str) -> str:
-        cleaned = raw.strip()
-        if cleaned.startswith("```"):
-            lines = cleaned.split("\n")
-            cleaned = "\n".join(lines[1:-1])
-        return cleaned

--- a/packages/core/python/src/application/use_cases/prepare_input/prepare_input_use_case.py
+++ b/packages/core/python/src/application/use_cases/prepare_input/prepare_input_use_case.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import json
-import logging
-
 from src.application.dto.prepare_input import PrepareInputRequest, PrepareInputResponse
+from src.application.shared.llm_response_parser import parse_llm_json
 from src.domain.repository.llm_service import LlmService
 from src.infrastructure.prompts.prepare_input_prompt import (
     PREPARE_INPUT_SYSTEM_PROMPT,
     build_prepare_input_prompt,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class PrepareInputUseCase:
@@ -25,7 +21,7 @@ class PrepareInputUseCase:
         )
 
         tokens_used = await self._llm_service.count_tokens(request.raw_input)
-        parsed = self._parse_llm_response(raw_response)
+        parsed = parse_llm_json(raw_response, context="prepare-input")
 
         return PrepareInputResponse(
             url=str(parsed.get("url", "")),
@@ -40,17 +36,3 @@ class PrepareInputUseCase:
         if isinstance(raw, dict):
             return {str(k): str(v) for k, v in raw.items()}
         return {}
-
-    @staticmethod
-    def _parse_llm_response(raw: str) -> dict[str, object]:
-        cleaned = raw.strip()
-        if cleaned.startswith("```"):
-            lines = cleaned.split("\n")
-            cleaned = "\n".join(lines[1:-1])
-
-        try:
-            result: dict[str, object] = json.loads(cleaned)
-            return result
-        except json.JSONDecodeError:
-            logger.error("Failed to parse LLM response as JSON: %s", cleaned[:200])
-            return {}

--- a/packages/core/python/src/infrastructure/prompts/exploration_prompt.py
+++ b/packages/core/python/src/infrastructure/prompts/exploration_prompt.py
@@ -6,7 +6,8 @@ You are an expert test automation engineer exploring a web page to build an E2E 
 Your task: analyze the current HTML and recommend the NEXT action to execute.
 
 Analyze from multiple angles:
-1. **Candidate selectors**: identify the most reliable selectors (data-testid > role > text > CSS)
+1. **Candidate selectors**: identify the most reliable selectors \
+(getByRole > getByLabel > getByTestId > getByText > CSS)
 2. **Alternative flows**: consider different paths to achieve the objective
 3. **Known traps**: detect modals, overlays, loading states, iframes that could block interaction
 4. **Recommended action**: the single best next step
@@ -21,7 +22,8 @@ You MUST respond with valid JSON only:
 }
 
 Rules:
-- Use data-testid selectors when available, fall back to role/text/CSS in that order
+- Prefer role-based selectors (getByRole), then label (getByLabel), \
+then testId (getByTestId), then text, CSS as last resort
 - Set completed=true ONLY when the test objective is fully achieved
 - Each response is ONE action — never batch multiple actions
 - Consider the conversation history to avoid repeating failed actions\

--- a/packages/core/python/src/infrastructure/prompts/generation_prompt.py
+++ b/packages/core/python/src/infrastructure/prompts/generation_prompt.py
@@ -8,7 +8,9 @@ You are an expert Playwright test engineer. Generate a complete, runnable .spec.
 Rules:
 - Use TypeScript with Playwright's test runner (`import { test, expect } from '@playwright/test'`)
 - Follow Page Object Model pattern where applicable
-- Use data-testid selectors when available, fall back to role/text/CSS
+- Prefer role-based selectors (getByRole), then label (getByLabel), \
+then testId (getByTestId), then text, CSS as last resort
+- Leverage Playwright auto-waiting — do NOT use waitForTimeout()
 - Include proper assertions for each step
 - Handle async/await correctly
 - Add descriptive test.describe and test blocks

--- a/packages/core/python/tests/application/test_llm_response_parser.py
+++ b/packages/core/python/tests/application/test_llm_response_parser.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from src.application.shared.llm_response_parser import clean_code_block, parse_llm_json
+
+
+class TestParseLlmJson:
+    def test_parses_valid_json(self) -> None:
+        result = parse_llm_json('{"key": "value"}')
+        assert result == {"key": "value"}
+
+    def test_strips_markdown_json_block(self) -> None:
+        raw = '```json\n{"key": "value"}\n```'
+        result = parse_llm_json(raw)
+        assert result == {"key": "value"}
+
+    def test_strips_plain_markdown_block(self) -> None:
+        raw = '```\n{"key": "value"}\n```'
+        result = parse_llm_json(raw)
+        assert result == {"key": "value"}
+
+    def test_returns_empty_on_invalid_json(self) -> None:
+        result = parse_llm_json("not json at all")
+        assert result == {}
+
+    def test_returns_empty_on_empty_string(self) -> None:
+        result = parse_llm_json("")
+        assert result == {}
+
+
+class TestCleanCodeBlock:
+    def test_strips_typescript_block(self) -> None:
+        raw = '```typescript\nimport { test } from "pw";\n```'
+        assert clean_code_block(raw) == 'import { test } from "pw";'
+
+    def test_returns_raw_if_no_block(self) -> None:
+        raw = 'import { test } from "pw";'
+        assert clean_code_block(raw) == raw
+
+    def test_strips_whitespace(self) -> None:
+        assert clean_code_block("  hello  ") == "hello"


### PR DESCRIPTION
## Summary
Revisión post-skills (`llm-evaluation` + `playwright-expert`) sobre T3-T6:

- **Selector priority corregida**: `getByRole > getByLabel > getByTestId > getByText > CSS` (Playwright best practices)
- **Shared JSON parser**: `parse_llm_json()` y `clean_code_block()` extraídos, eliminando duplicación en 3 use cases
- **Auto-waiting**: añadido "no waitForTimeout" al prompt de generación
- **8 tests nuevos** para el parser compartido

## QA
- `ruff check` ✅
- `mypy --strict` ✅
- `pytest` 42/42 ✅

## Test plan
- [x] Parser: JSON válido, markdown blocks, JSON inválido, empty string
- [x] Code block cleaner: typescript block, no block, whitespace
- [x] Todos los tests existentes siguen pasando (no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)