### PR TITLE
chore(framework): scaffold TypeScript project

### DIFF
--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -1,0 +1,30 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.strictTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
+      ],
+      '@typescript-eslint/explicit-function-return-type': 'error',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports' },
+      ],
+    },
+  },
+  {
+    ignores: ['dist/', 'node_modules/', 'vitest.config.ts', 'eslint.config.mjs'],
+  },
+);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "playwright-ppia",
   "version": "0.1.0",
   "description": "AI-powered test generation framework for Playwright",
+  "type": "module",
   "bin": {
     "ppia": "./dist/cli/index.js"
   },
@@ -14,6 +15,14 @@
   "engines": {
     "node": ">=18"
   },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit"
+  },
   "keywords": [
     "playwright",
     "testing",
@@ -21,5 +30,13 @@
     "e2e",
     "test-generation"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@eslint/js": "^9.18.0",
+    "@types/node": "^22.10.0",
+    "eslint": "^9.18.0",
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.20.0",
+    "vitest": "^3.0.0"
+  }
 }

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,0 +1,1 @@
+// Agents: orchestrators for each pipeline phase.

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -1,0 +1,1 @@
+// AI Service client: HTTP communication with the Python backend.

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -1,0 +1,1 @@
+// Browser: Playwright wrapper for page interaction and HTML extraction.

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+// CLI entry point: ppia command.

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,0 +1,1 @@
+// Config: project configuration reader (ppia.yaml).

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,0 +1,1 @@
+// Domain: TypeScript models (AgentContext, ExplorationReport, GeneratedTest).

--- a/packages/core/src/executor/index.ts
+++ b/packages/core/src/executor/index.ts
@@ -1,0 +1,1 @@
+// Executor: runs generated tests via Playwright test runner.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * playwright-ppia — AI-powered test generation framework for Playwright.
+ *
+ * @packageDocumentation
+ */
+
+// Public API will be exported here as modules are implemented.

--- a/packages/core/src/suite/index.ts
+++ b/packages/core/src/suite/index.ts
@@ -1,0 +1,1 @@
+// Suite: test suite management, history and knowledge base client.

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "vitest.config.ts"
+  ]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": false,
+    "baseUrl": ".",
+    "paths": {
+      "@agents/*": ["src/agents/*"],
+      "@ai/*": ["src/ai/*"],
+      "@browser/*": ["src/browser/*"],
+      "@config/*": ["src/config/*"],
+      "@executor/*": ["src/executor/*"],
+      "@suite/*": ["src/suite/*"],
+      "@domain/*": ["src/domain/*"],
+      "@cli/*": ["src/cli/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@agents': resolve(__dirname, 'src/agents'),
+      '@ai': resolve(__dirname, 'src/ai'),
+      '@browser': resolve(__dirname, 'src/browser'),
+      '@config': resolve(__dirname, 'src/config'),
+      '@executor': resolve(__dirname, 'src/executor'),
+      '@suite': resolve(__dirname, 'src/suite'),
+      '@domain': resolve(__dirname, 'src/domain'),
+      '@cli': resolve(__dirname, 'src/cli'),
+    },
+  },
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Summary

- Add TypeScript strict configuration with 8 path aliases (@agents, @ai, @browser, @config, @executor, @suite, @domain, @cli)
- Configure ESLint 9 flat config with typescript-eslint strictTypeChecked
- Configure Vitest as test runner with path alias resolution
- Create directory structure matching ARCHITECTURE.md (agents, ai, browser, config, executor, suite, domain, cli)
- Add build/dev/test/lint/typecheck scripts to package.json

## Test plan

- [x] `pnpm install` completes without errors (154 packages)
- [x] `pnpm typecheck` passes (tsc --noEmit)
- [x] `pnpm lint` passes (eslint src)
- [x] `pnpm build` generates dist/ with .js + .d.ts + sourcemaps
- [x] `pnpm test` exits with code 0 (vitest, 0 tests)
- [x] Path aliases configured in tsconfig.json + vitest.config.ts

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)