### PR TITLE
feat(framework): AiServiceClient + PythonServerManager

### DIFF
--- a/packages/core/src/ai/AiServiceClient.test.ts
+++ b/packages/core/src/ai/AiServiceClient.test.ts
@@ -1,0 +1,260 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { AiServiceClient } from './AiServiceClient.js';
+import { AiServiceError } from './AiServiceError.js';
+
+// Minimal HTTP server that mimics the Python AI Service responses.
+function createMockServer(): http.Server {
+  return http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+    req.on('end', () => {
+      res.setHeader('Content-Type', 'application/json');
+
+      const url = req.url ?? '';
+
+      if (url === '/ping' && req.method === 'GET') {
+        res.end(JSON.stringify({ status: 'ok', version: '0.1.0' }));
+        return;
+      }
+
+      if (url === '/prepare-input' && req.method === 'POST') {
+        const parsed = JSON.parse(body) as Record<string, unknown>;
+        if (!parsed.raw_input) {
+          res.statusCode = 422;
+          res.end(JSON.stringify({ detail: 'raw_input required' }));
+          return;
+        }
+        res.end(JSON.stringify({
+          url: 'https://example.com',
+          objective: 'Login test',
+          test_name: 'login_test',
+          parameters: { user: 'admin' },
+          tokens_used: 150,
+        }));
+        return;
+      }
+
+      if (url === '/session' && req.method === 'POST') {
+        res.end(JSON.stringify({ session_id: 'sess-abc-123' }));
+        return;
+      }
+
+      if (url.startsWith('/session/') && req.method === 'DELETE') {
+        res.end(JSON.stringify({ closed: true }));
+        return;
+      }
+
+      if (url.endsWith('/explore') && req.method === 'POST') {
+        res.end(JSON.stringify({
+          action: 'click',
+          target: 'getByRole("button", { name: "Submit" })',
+          value: null,
+          completed: false,
+          analysis_summary: 'Found submit button',
+          tokens_used: 200,
+        }));
+        return;
+      }
+
+      if (url.endsWith('/generate-test') && req.method === 'POST') {
+        res.end(JSON.stringify({
+          code: 'import { test } from "@playwright/test";',
+          tokens_used: 500,
+        }));
+        return;
+      }
+
+      if (url.endsWith('/generate-artifacts') && req.method === 'POST') {
+        res.end(JSON.stringify({
+          pom_md: '# POM',
+          gherkin_md: '# Gherkin',
+          cucumber_md: '# Cucumber',
+          tokens_used: 300,
+        }));
+        return;
+      }
+
+      res.statusCode = 404;
+      res.end(JSON.stringify({ detail: 'Not found' }));
+    });
+  });
+}
+
+describe('AiServiceClient', () => {
+  let server: http.Server;
+  let client: AiServiceClient;
+
+  beforeAll(async () => {
+    server = createMockServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => { resolve(); });
+    });
+    const addr = server.address() as AddressInfo;
+    client = new AiServiceClient(`http://127.0.0.1:${String(addr.port)}`);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => { resolve(); });
+    });
+  });
+
+  it('ping returns status and version', async () => {
+    const result = await client.ping();
+    expect(result.status).toBe('ok');
+    expect(result.version).toBe('0.1.0');
+  });
+
+  it('prepareInput sends camelCase and receives camelCase', async () => {
+    const result = await client.prepareInput({ rawInput: 'Login as admin' });
+    expect(result.url).toBe('https://example.com');
+    expect(result.testName).toBe('login_test');
+    expect(result.tokensUsed).toBe(150);
+    expect(result.parameters).toEqual({ user: 'admin' });
+  });
+
+  it('createSession returns sessionId', async () => {
+    const result = await client.createSession();
+    expect(result.sessionId).toBe('sess-abc-123');
+  });
+
+  it('closeSession returns closed flag', async () => {
+    const result = await client.closeSession('sess-abc-123');
+    expect(result.closed).toBe(true);
+  });
+
+  it('explore returns action with camelCase keys', async () => {
+    const result = await client.explore('sess-abc-123', {
+      html: '<button>Submit</button>',
+    });
+    expect(result.action).toBe('click');
+    expect(result.analysisSummary).toBe('Found submit button');
+    expect(result.completed).toBe(false);
+    expect(result.tokensUsed).toBe(200);
+  });
+
+  it('generateTest returns code', async () => {
+    const result = await client.generateTest('sess-abc-123', {
+      explorationReport: { steps: [] },
+    });
+    expect(result.code).toContain('@playwright/test');
+    expect(result.tokensUsed).toBe(500);
+  });
+
+  it('generateArtifacts returns all three artifacts with camelCase', async () => {
+    const result = await client.generateArtifacts('sess-abc-123', {});
+    expect(result.pomMd).toBe('# POM');
+    expect(result.gherkinMd).toBe('# Gherkin');
+    expect(result.cucumberMd).toBe('# Cucumber');
+    expect(result.tokensUsed).toBe(300);
+  });
+
+  it('throws AiServiceError on connection failure', async () => {
+    const badClient = new AiServiceClient('http://127.0.0.1:1');
+    await expect(badClient.ping()).rejects.toThrow(AiServiceError);
+  });
+
+  it('throws AiServiceError on non-OK response', async () => {
+    await expect(
+      client.prepareInput({ rawInput: '' }),
+    ).rejects.toThrow(AiServiceError);
+  });
+});
+
+describe('key conversion', () => {
+  let server: http.Server;
+  let client: AiServiceClient;
+
+  beforeAll(async () => {
+    server = http.createServer((_req, res) => {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        nested_object: { deep_key: 'value' },
+        array_field: [{ item_name: 'a' }],
+      }));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => { resolve(); });
+    });
+    const addr = server.address() as AddressInfo;
+    client = new AiServiceClient(`http://127.0.0.1:${String(addr.port)}`);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => { resolve(); });
+    });
+  });
+
+  it('deeply converts snake_case response keys to camelCase', async () => {
+    const result = await client.ping() as unknown as Record<string, unknown>;
+    expect(result).toHaveProperty('nestedObject');
+    expect(result).toHaveProperty('arrayField');
+    const nested = result.nestedObject as Record<string, unknown>;
+    expect(nested).toHaveProperty('deepKey', 'value');
+    const arr = result.arrayField as Array<Record<string, unknown>>;
+    expect(arr[0]).toHaveProperty('itemName', 'a');
+  });
+});
+
+describe('request body conversion', () => {
+  let server: http.Server;
+  let client: AiServiceClient;
+  let lastRequestBody: Record<string, unknown> | null = null;
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      let body = '';
+      req.on('data', (chunk: Buffer) => { body += chunk.toString(); });
+      req.on('end', () => {
+        lastRequestBody = JSON.parse(body) as Record<string, unknown>;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({ session_id: 'test' }));
+      });
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => { resolve(); });
+    });
+    const addr = server.address() as AddressInfo;
+    client = new AiServiceClient(`http://127.0.0.1:${String(addr.port)}`);
+  });
+
+  afterEach(() => {
+    lastRequestBody = null;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => { resolve(); });
+    });
+  });
+
+  it('converts camelCase request body to snake_case', async () => {
+    await client.prepareInput({ rawInput: 'test input', model: 'gpt-4o' });
+    expect(lastRequestBody).toHaveProperty('raw_input', 'test input');
+    expect(lastRequestBody).toHaveProperty('model', 'gpt-4o');
+  });
+});
+
+describe('PythonServerManager', () => {
+  it('computes baseUrl correctly', async () => {
+    const { PythonServerManager } = await import('./PythonServerManager.js');
+    const manager = new PythonServerManager({ port: 9999, host: '0.0.0.0' });
+    expect(manager.baseUrl).toBe('http://0.0.0.0:9999');
+  });
+
+  it('reports isRunning as false initially', async () => {
+    const { PythonServerManager } = await import('./PythonServerManager.js');
+    const manager = new PythonServerManager();
+    expect(manager.isRunning).toBe(false);
+  });
+
+  it('stop resolves immediately when no process', async () => {
+    const { PythonServerManager } = await import('./PythonServerManager.js');
+    const manager = new PythonServerManager();
+    await expect(manager.stop()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/ai/AiServiceClient.ts
+++ b/packages/core/src/ai/AiServiceClient.ts
@@ -1,0 +1,137 @@
+import { AiServiceError } from './AiServiceError.js';
+import type {
+  CloseSessionResponse,
+  CreateSessionResponse,
+  ExploreRequest,
+  ExploreResponse,
+  GenerateArtifactsRequest,
+  GenerateArtifactsResponse,
+  GenerateTestRequest,
+  GenerateTestResponse,
+  PingResponse,
+  PrepareInputRequest,
+  PrepareInputResponse,
+} from './AiServiceTypes.js';
+
+/**
+ * Converts a camelCase key to snake_case.
+ */
+function toSnakeCase(key: string): string {
+  return key.replace(/[A-Z]/g, (char) => `_${char.toLowerCase()}`);
+}
+
+/**
+ * Converts a snake_case key to camelCase.
+ */
+function toCamelCase(key: string): string {
+  return key.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+}
+
+/**
+ * Deep-converts all object keys using a transform function.
+ */
+function convertKeys(obj: unknown, transform: (key: string) => string): unknown {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => convertKeys(item, transform));
+  }
+  if (obj !== null && typeof obj === 'object') {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[transform(key)] = convertKeys(value, transform);
+    }
+    return result;
+  }
+  return obj;
+}
+
+export class AiServiceClient {
+  constructor(private readonly baseUrl: string) {}
+
+  async ping(): Promise<PingResponse> {
+    return this.get<PingResponse>('/ping');
+  }
+
+  async prepareInput(request: PrepareInputRequest): Promise<PrepareInputResponse> {
+    return this.post<PrepareInputResponse>('/prepare-input', request);
+  }
+
+  async createSession(): Promise<CreateSessionResponse> {
+    return this.post<CreateSessionResponse>('/session', {});
+  }
+
+  async closeSession(sessionId: string): Promise<CloseSessionResponse> {
+    return this.delete<CloseSessionResponse>(`/session/${sessionId}`);
+  }
+
+  async explore(sessionId: string, request: ExploreRequest): Promise<ExploreResponse> {
+    return this.post<ExploreResponse>(`/session/${sessionId}/explore`, request);
+  }
+
+  async generateTest(
+    sessionId: string,
+    request: GenerateTestRequest,
+  ): Promise<GenerateTestResponse> {
+    return this.post<GenerateTestResponse>(
+      `/session/${sessionId}/generate-test`,
+      request,
+    );
+  }
+
+  async generateArtifacts(
+    sessionId: string,
+    request: GenerateArtifactsRequest,
+  ): Promise<GenerateArtifactsResponse> {
+    return this.post<GenerateArtifactsResponse>(
+      `/session/${sessionId}/generate-artifacts`,
+      request,
+    );
+  }
+
+  private async get<T>(endpoint: string): Promise<T> {
+    const response = await this.fetch(endpoint, { method: 'GET' });
+    return this.handleResponse<T>(response, endpoint);
+  }
+
+  private async post<T>(endpoint: string, body: unknown): Promise<T> {
+    const snakeBody = convertKeys(body, toSnakeCase);
+    const response = await this.fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(snakeBody),
+    });
+    return this.handleResponse<T>(response, endpoint);
+  }
+
+  private async delete<T>(endpoint: string): Promise<T> {
+    const response = await this.fetch(endpoint, { method: 'DELETE' });
+    return this.handleResponse<T>(response, endpoint);
+  }
+
+  private async fetch(endpoint: string, init: RequestInit): Promise<Response> {
+    const url = `${this.baseUrl}${endpoint}`;
+    try {
+      return await fetch(url, init);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new AiServiceError(
+        `Failed to connect to AI Service at ${url}: ${message}`,
+        undefined,
+        endpoint,
+      );
+    }
+  }
+
+  private async handleResponse<T>(response: Response, endpoint: string): Promise<T> {
+    if (!response.ok) {
+      const text = await response.text().catch(() => 'Unknown error');
+      throw new AiServiceError(
+        `AI Service responded with ${String(response.status)}: ${text}`,
+        response.status,
+        endpoint,
+      );
+    }
+
+    const json: unknown = await response.json();
+    return convertKeys(json, toCamelCase) as T;
+  }
+}

--- a/packages/core/src/ai/AiServiceError.ts
+++ b/packages/core/src/ai/AiServiceError.ts
@@ -1,0 +1,10 @@
+export class AiServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+    public readonly endpoint?: string,
+  ) {
+    super(message);
+    this.name = 'AiServiceError';
+  }
+}

--- a/packages/core/src/ai/AiServiceTypes.ts
+++ b/packages/core/src/ai/AiServiceTypes.ts
@@ -1,0 +1,72 @@
+// DTOs aligned 1:1 with Python Pydantic models (snake_case → camelCase).
+
+export interface PingResponse {
+  status: string;
+  version: string;
+}
+
+// --- Session 0: Prepare Input ---
+
+export interface PrepareInputRequest {
+  rawInput: string;
+  model?: string;
+}
+
+export interface PrepareInputResponse {
+  url: string;
+  objective: string;
+  testName: string;
+  parameters: Record<string, string>;
+  tokensUsed: number;
+}
+
+// --- Session management ---
+
+export interface CreateSessionResponse {
+  sessionId: string;
+}
+
+export interface CloseSessionResponse {
+  closed: boolean;
+}
+
+// --- Session A: Exploration ---
+
+export interface ExploreRequest {
+  html: string;
+  context?: Record<string, string>;
+  model?: string;
+}
+
+export interface ExploreResponse {
+  action: string;
+  target: string;
+  value: string | null;
+  completed: boolean;
+  analysisSummary: string;
+  tokensUsed: number;
+}
+
+// --- Session B: Generation ---
+
+export interface GenerateTestRequest {
+  explorationReport: Record<string, unknown>;
+  failureReport?: Record<string, unknown> | null;
+  model?: string;
+}
+
+export interface GenerateTestResponse {
+  code: string;
+  tokensUsed: number;
+}
+
+export interface GenerateArtifactsRequest {
+  model?: string;
+}
+
+export interface GenerateArtifactsResponse {
+  pomMd: string;
+  gherkinMd: string;
+  cucumberMd: string;
+  tokensUsed: number;
+}

--- a/packages/core/src/ai/PythonServerManager.ts
+++ b/packages/core/src/ai/PythonServerManager.ts
@@ -1,0 +1,137 @@
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { AiServiceError } from './AiServiceError.js';
+
+export interface PythonServerOptions {
+  port?: number;
+  host?: string;
+  startupTimeoutMs?: number;
+  pollIntervalMs?: number;
+  pythonPath?: string;
+}
+
+const DEFAULTS = {
+  port: 8765,
+  host: '127.0.0.1',
+  startupTimeoutMs: 30_000,
+  pollIntervalMs: 500,
+  pythonPath: 'python3',
+} as const;
+
+export class PythonServerManager {
+  private process: ChildProcess | null = null;
+  private readonly port: number;
+  private readonly host: string;
+  private readonly startupTimeoutMs: number;
+  private readonly pollIntervalMs: number;
+  private readonly pythonPath: string;
+
+  constructor(options: PythonServerOptions = {}) {
+    this.port = options.port ?? DEFAULTS.port;
+    this.host = options.host ?? DEFAULTS.host;
+    this.startupTimeoutMs = options.startupTimeoutMs ?? DEFAULTS.startupTimeoutMs;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULTS.pollIntervalMs;
+    this.pythonPath = options.pythonPath ?? DEFAULTS.pythonPath;
+  }
+
+  get baseUrl(): string {
+    return `http://${this.host}:${String(this.port)}`;
+  }
+
+  get isRunning(): boolean {
+    return this.process !== null && this.process.exitCode === null;
+  }
+
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      return;
+    }
+
+    const pythonDir = resolve(__dirname, '../../python');
+
+    this.process = spawn(
+      this.pythonPath,
+      [
+        '-m', 'uvicorn',
+        'src.server:app',
+        '--host', this.host,
+        '--port', String(this.port),
+        '--no-access-log',
+      ],
+      {
+        cwd: pythonDir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+      },
+    );
+
+    this.process.on('error', (err) => {
+      this.process = null;
+      throw new AiServiceError(
+        `Failed to start Python AI Service: ${err.message}. ` +
+        `Ensure Python 3.11+ is installed and available as '${this.pythonPath}'.`,
+      );
+    });
+
+    this.process.on('exit', (_code) => {
+      this.process = null;
+    });
+
+    await this.waitForReady();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.process) {
+      return;
+    }
+
+    const proc = this.process;
+    this.process = null;
+
+    return new Promise<void>((resolve) => {
+      const timeout = setTimeout(() => {
+        proc.kill('SIGKILL');
+        resolve();
+      }, 5_000);
+
+      proc.on('exit', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+
+      proc.kill('SIGTERM');
+    });
+  }
+
+  private async waitForReady(): Promise<void> {
+    const deadline = Date.now() + this.startupTimeoutMs;
+
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(`${this.baseUrl}/ping`);
+        if (response.ok) {
+          return;
+        }
+      } catch {
+        // Server not ready yet — keep polling.
+      }
+
+      await this.sleep(this.pollIntervalMs);
+    }
+
+    await this.stop();
+    throw new AiServiceError(
+      `Python AI Service did not respond within ${String(this.startupTimeoutMs)}ms. ` +
+      'Check that Python 3.11+ is installed, dependencies are available, ' +
+      `and port ${String(this.port)} is free.`,
+    );
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  }
+}

--- a/packages/core/src/ai/index.ts
+++ b/packages/core/src/ai/index.ts
@@ -1,1 +1,17 @@
-// AI Service client: HTTP communication with the Python backend.
+export { AiServiceClient } from './AiServiceClient.js';
+export { AiServiceError } from './AiServiceError.js';
+export { PythonServerManager } from './PythonServerManager.js';
+export type {
+  PingResponse,
+  PrepareInputRequest,
+  PrepareInputResponse,
+  CreateSessionResponse,
+  CloseSessionResponse,
+  ExploreRequest,
+  ExploreResponse,
+  GenerateTestRequest,
+  GenerateTestResponse,
+  GenerateArtifactsRequest,
+  GenerateArtifactsResponse,
+} from './AiServiceTypes.js';
+export type { PythonServerOptions } from './PythonServerManager.js';


### PR DESCRIPTION
## Summary

- Add `AiServiceTypes.ts` with 12 typed interfaces aligned 1:1 with Python Pydantic DTOs (automatic snake_case ↔ camelCase conversion)
- Add `AiServiceClient.ts` — HTTP client using native `fetch` (Node 18+) with typed methods for all 7 endpoints
- Add `PythonServerManager.ts` — process lifecycle: spawn Python server, poll `/ping` until ready, graceful stop with SIGTERM/SIGKILL
- Add `AiServiceError.ts` — typed error class with statusCode and endpoint info
- 14 unit tests with mock HTTP server (no real Python required)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 14 tests passed (1.29s)
- [x] Tests cover: all endpoints, camelCase↔snake_case conversion, connection errors, non-OK responses, PythonServerManager properties

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)