### PR TITLE
feat(framework): BrowserManager + HtmlExtractor + ActionExecutor

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,6 +35,7 @@
     "@eslint/js": "^9.18.0",
     "@types/node": "^22.10.0",
     "eslint": "^9.18.0",
+    "playwright": "^1.58.2",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.20.0",
     "vitest": "^3.0.0"

--- a/packages/core/src/browser/ActionExecutor.test.ts
+++ b/packages/core/src/browser/ActionExecutor.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ActionExecutor } from './ActionExecutor.js';
+import type { ExploreAction } from './ActionExecutor.js';
+
+function createMockPage(): Record<string, unknown> {
+  const mockLocator = {
+    click: vi.fn().mockResolvedValue(undefined),
+    fill: vi.fn().mockResolvedValue(undefined),
+    waitFor: vi.fn().mockResolvedValue(undefined),
+    scrollIntoViewIfNeeded: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    locator: vi.fn().mockReturnValue(mockLocator),
+    getByRole: vi.fn().mockReturnValue(mockLocator),
+    getByLabel: vi.fn().mockReturnValue(mockLocator),
+    getByTestId: vi.fn().mockReturnValue(mockLocator),
+    getByText: vi.fn().mockReturnValue(mockLocator),
+    goto: vi.fn().mockResolvedValue(undefined),
+    _mockLocator: mockLocator,
+  };
+}
+
+describe('ActionExecutor', () => {
+  it('executes click with CSS selector', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({ action: 'click', target: '#submit', value: null });
+
+    expect(page.locator).toHaveBeenCalledWith('#submit');
+    expect((page._mockLocator as Record<string, unknown>).click).toHaveBeenCalled();
+  });
+
+  it('executes click with getByRole selector', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'click',
+      target: 'getByRole("button", { name: "Submit" })',
+      value: null,
+    });
+
+    expect(page.getByRole).toHaveBeenCalledWith('button', { name: 'Submit' });
+  });
+
+  it('executes click with getByRole without name', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'click',
+      target: 'getByRole("navigation")',
+      value: null,
+    });
+
+    expect(page.getByRole).toHaveBeenCalledWith('navigation');
+  });
+
+  it('executes click with getByLabel selector', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'click',
+      target: 'getByLabel("Email")',
+      value: null,
+    });
+
+    expect(page.getByLabel).toHaveBeenCalledWith('Email');
+  });
+
+  it('executes click with getByTestId selector', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'click',
+      target: 'getByTestId("submit-btn")',
+      value: null,
+    });
+
+    expect(page.getByTestId).toHaveBeenCalledWith('submit-btn');
+  });
+
+  it('executes click with getByText selector', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'click',
+      target: 'getByText("Welcome")',
+      value: null,
+    });
+
+    expect(page.getByText).toHaveBeenCalledWith('Welcome');
+  });
+
+  it('executes fill action', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'fill',
+      target: 'getByLabel("Username")',
+      value: 'admin',
+    });
+
+    expect(page.getByLabel).toHaveBeenCalledWith('Username');
+    expect((page._mockLocator as Record<string, unknown>).fill).toHaveBeenCalledWith('admin');
+  });
+
+  it('executes fill with empty string when value is null', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'fill',
+      target: '#input',
+      value: null,
+    });
+
+    expect((page._mockLocator as Record<string, unknown>).fill).toHaveBeenCalledWith('');
+  });
+
+  it('executes navigate action', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'navigate',
+      target: 'https://example.com/login',
+      value: null,
+    });
+
+    expect(page.goto).toHaveBeenCalledWith('https://example.com/login', {
+      waitUntil: 'domcontentloaded',
+    });
+  });
+
+  it('executes wait action', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'wait',
+      target: 'getByTestId("loading")',
+      value: null,
+    });
+
+    expect(page.getByTestId).toHaveBeenCalledWith('loading');
+    expect((page._mockLocator as Record<string, unknown>).waitFor).toHaveBeenCalledWith({
+      state: 'visible',
+    });
+  });
+
+  it('executes scroll action', async () => {
+    const page = createMockPage();
+    const executor = new ActionExecutor(page as never);
+
+    await executor.execute({
+      action: 'scroll',
+      target: '#footer',
+      value: null,
+    });
+
+    expect(page.locator).toHaveBeenCalledWith('#footer');
+    expect((page._mockLocator as Record<string, unknown>).scrollIntoViewIfNeeded).toHaveBeenCalled();
+  });
+
+  it('throws descriptive error when action fails', async () => {
+    const mockLocator = {
+      click: vi.fn().mockRejectedValue(new Error('Element not found')),
+    };
+    const page = {
+      locator: vi.fn().mockReturnValue(mockLocator),
+    };
+    const executor = new ActionExecutor(page as never);
+
+    const action: ExploreAction = { action: 'click', target: '#missing', value: null };
+
+    await expect(executor.execute(action)).rejects.toThrow(
+      'Action "click" failed on "#missing": Element not found',
+    );
+  });
+});

--- a/packages/core/src/browser/ActionExecutor.ts
+++ b/packages/core/src/browser/ActionExecutor.ts
@@ -1,0 +1,103 @@
+import type { Page } from 'playwright';
+
+export type ActionType = 'click' | 'fill' | 'navigate' | 'wait' | 'scroll';
+
+export interface ExploreAction {
+  action: ActionType;
+  target: string;
+  value: string | null;
+}
+
+export class ActionExecutor {
+  constructor(private readonly page: Page) {}
+
+  async execute(action: ExploreAction): Promise<void> {
+    try {
+      switch (action.action) {
+        case 'click':
+          await this.click(action.target);
+          break;
+        case 'fill':
+          await this.fill(action.target, action.value ?? '');
+          break;
+        case 'navigate':
+          await this.navigate(action.target);
+          break;
+        case 'wait':
+          await this.wait(action.target);
+          break;
+        case 'scroll':
+          await this.scroll(action.target);
+          break;
+        default:
+          throw new Error(`Unknown action type: ${String(action.action)}`);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Action "${action.action}" failed on "${action.target}": ${message}`,
+      );
+    }
+  }
+
+  private async click(selector: string): Promise<void> {
+    const locator = this.resolveLocator(selector);
+    await locator.click();
+  }
+
+  private async fill(selector: string, value: string): Promise<void> {
+    const locator = this.resolveLocator(selector);
+    await locator.fill(value);
+  }
+
+  private async navigate(url: string): Promise<void> {
+    await this.page.goto(url, { waitUntil: 'domcontentloaded' });
+  }
+
+  private async wait(selector: string): Promise<void> {
+    const locator = this.resolveLocator(selector);
+    await locator.waitFor({ state: 'visible' });
+  }
+
+  private async scroll(selector: string): Promise<void> {
+    const locator = this.resolveLocator(selector);
+    await locator.scrollIntoViewIfNeeded();
+  }
+
+  /**
+   * Resolves a selector string to a Playwright Locator.
+   *
+   * Supports Playwright's getBy* methods when the selector starts
+   * with a recognized prefix, otherwise falls back to CSS/XPath.
+   */
+  private resolveLocator(selector: string): ReturnType<Page['locator']> {
+    // getByRole("button", { name: "Submit" })
+    const roleMatch = /^getByRole\("([^"]+)"(?:,\s*\{\s*name:\s*"([^"]+)"\s*\})?\)$/.exec(selector);
+    if (roleMatch) {
+      const role = roleMatch[1] as Parameters<Page['getByRole']>[0];
+      const name = roleMatch[2];
+      return name ? this.page.getByRole(role, { name }) : this.page.getByRole(role);
+    }
+
+    // getByLabel("Email")
+    const labelMatch = /^getByLabel\("([^"]+)"\)$/.exec(selector);
+    if (labelMatch?.[1]) {
+      return this.page.getByLabel(labelMatch[1]);
+    }
+
+    // getByTestId("submit-btn")
+    const testIdMatch = /^getByTestId\("([^"]+)"\)$/.exec(selector);
+    if (testIdMatch?.[1]) {
+      return this.page.getByTestId(testIdMatch[1]);
+    }
+
+    // getByText("Welcome")
+    const textMatch = /^getByText\("([^"]+)"\)$/.exec(selector);
+    if (textMatch?.[1]) {
+      return this.page.getByText(textMatch[1]);
+    }
+
+    // CSS or XPath fallback
+    return this.page.locator(selector);
+  }
+}

--- a/packages/core/src/browser/BrowserManager.test.ts
+++ b/packages/core/src/browser/BrowserManager.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { BrowserManager } from './BrowserManager.js';
+
+// Mock playwright module
+vi.mock('playwright', () => {
+  const mockPage = { url: (): string => 'about:blank' };
+  const mockContext = {
+    newPage: vi.fn().mockResolvedValue(mockPage),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockBrowser = {
+    newContext: vi.fn().mockResolvedValue(mockContext),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    chromium: {
+      launch: vi.fn().mockResolvedValue(mockBrowser),
+    },
+    _mockBrowser: mockBrowser,
+    _mockContext: mockContext,
+    _mockPage: mockPage,
+  };
+});
+
+describe('BrowserManager', () => {
+  it('reports isLaunched as false initially', () => {
+    const manager = new BrowserManager();
+    expect(manager.isLaunched).toBe(false);
+  });
+
+  it('throws when accessing page before launch', () => {
+    const manager = new BrowserManager();
+    expect(() => manager.page).toThrow('Browser not launched');
+  });
+
+  it('launches browser and returns page', async () => {
+    const manager = new BrowserManager();
+    const page = await manager.launch();
+    expect(page).toBeDefined();
+    expect(manager.isLaunched).toBe(true);
+  });
+
+  it('returns same page on subsequent launch calls', async () => {
+    const manager = new BrowserManager();
+    const page1 = await manager.launch();
+    const page2 = await manager.launch();
+    expect(page1).toBe(page2);
+  });
+
+  it('closes browser cleanly', async () => {
+    const manager = new BrowserManager();
+    await manager.launch();
+    await manager.close();
+    expect(manager.isLaunched).toBe(false);
+  });
+
+  it('close is safe when not launched', async () => {
+    const manager = new BrowserManager();
+    await expect(manager.close()).resolves.toBeUndefined();
+  });
+
+  it('accepts custom options', () => {
+    const manager = new BrowserManager({
+      headless: false,
+      slowMo: 100,
+      viewport: { width: 1920, height: 1080 },
+    });
+    expect(manager.isLaunched).toBe(false);
+  });
+});

--- a/packages/core/src/browser/BrowserManager.ts
+++ b/packages/core/src/browser/BrowserManager.ts
@@ -1,0 +1,71 @@
+import type { Browser, BrowserContext, Page } from 'playwright';
+
+export interface BrowserManagerOptions {
+  headless?: boolean;
+  slowMo?: number;
+  viewport?: { width: number; height: number };
+}
+
+const DEFAULTS = {
+  headless: true,
+  slowMo: 0,
+  viewport: { width: 1280, height: 720 },
+} as const;
+
+export class BrowserManager {
+  private browser: Browser | null = null;
+  private context: BrowserContext | null = null;
+  private activePage: Page | null = null;
+  private readonly options: Required<BrowserManagerOptions>;
+
+  constructor(options: BrowserManagerOptions = {}) {
+    this.options = {
+      headless: options.headless ?? DEFAULTS.headless,
+      slowMo: options.slowMo ?? DEFAULTS.slowMo,
+      viewport: options.viewport ?? { ...DEFAULTS.viewport },
+    };
+  }
+
+  get page(): Page {
+    if (!this.activePage) {
+      throw new Error('Browser not launched. Call launch() first.');
+    }
+    return this.activePage;
+  }
+
+  get isLaunched(): boolean {
+    return this.browser !== null;
+  }
+
+  async launch(): Promise<Page> {
+    if (this.activePage) {
+      return this.activePage;
+    }
+
+    const { chromium } = await import('playwright');
+
+    this.browser = await chromium.launch({
+      headless: this.options.headless,
+      slowMo: this.options.slowMo,
+    });
+
+    this.context = await this.browser.newContext({
+      viewport: this.options.viewport,
+    });
+
+    this.activePage = await this.context.newPage();
+    return this.activePage;
+  }
+
+  async close(): Promise<void> {
+    if (this.context) {
+      await this.context.close();
+      this.context = null;
+    }
+    if (this.browser) {
+      await this.browser.close();
+      this.browser = null;
+    }
+    this.activePage = null;
+  }
+}

--- a/packages/core/src/browser/HtmlExtractor.test.ts
+++ b/packages/core/src/browser/HtmlExtractor.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { HtmlExtractor } from './HtmlExtractor.js';
+
+describe('HtmlExtractor.clean', () => {
+  it('removes script tags and content', () => {
+    const html = '<div>Hello</div><script>alert("x")</script><p>World</p>';
+    expect(HtmlExtractor.clean(html)).toBe('<div>Hello</div><p>World</p>');
+  });
+
+  it('removes style tags and content', () => {
+    const html = '<style>.foo { color: red; }</style><div>Content</div>';
+    expect(HtmlExtractor.clean(html)).toBe('<div>Content</div>');
+  });
+
+  it('removes HTML comments', () => {
+    const html = '<div><!-- hidden comment -->Visible</div>';
+    expect(HtmlExtractor.clean(html)).toBe('<div>Visible</div>');
+  });
+
+  it('removes inline style attributes (double quotes)', () => {
+    const html = '<div style="color: red; font-size: 14px">Text</div>';
+    expect(HtmlExtractor.clean(html)).toBe('<div>Text</div>');
+  });
+
+  it('removes inline style attributes (single quotes)', () => {
+    const html = "<div style='color: red'>Text</div>";
+    expect(HtmlExtractor.clean(html)).toBe('<div>Text</div>');
+  });
+
+  it('collapses multiple whitespace', () => {
+    const html = '<div>   Hello   \n\n   World   </div>';
+    expect(HtmlExtractor.clean(html)).toBe('<div> Hello World </div>');
+  });
+
+  it('handles multiline scripts', () => {
+    const html = `<div>Before</div>
+<script type="text/javascript">
+  const x = 1;
+  console.log(x);
+</script>
+<div>After</div>`;
+    const result = HtmlExtractor.clean(html);
+    expect(result).not.toContain('console');
+    expect(result).toContain('Before');
+    expect(result).toContain('After');
+  });
+
+  it('preserves data-testid and role attributes', () => {
+    const html = '<button data-testid="submit" role="button">Submit</button>';
+    expect(HtmlExtractor.clean(html)).toBe(html);
+  });
+});
+
+describe('HtmlExtractor.extract', () => {
+  it('extracts and cleans HTML from page', async () => {
+    const mockPage = {
+      content: vi.fn().mockResolvedValue('<div>Hello</div><script>evil()</script>'),
+    };
+
+    const extractor = new HtmlExtractor();
+    const result = await extractor.extract(mockPage as never);
+    expect(result).toBe('<div>Hello</div>');
+    expect(mockPage.content).toHaveBeenCalledOnce();
+  });
+
+  it('truncates HTML that exceeds maxLength', async () => {
+    const longHtml = '<div>' + 'x'.repeat(20_000) + '</div>';
+    const mockPage = {
+      content: vi.fn().mockResolvedValue(longHtml),
+    };
+
+    const extractor = new HtmlExtractor(100);
+    const result = await extractor.extract(mockPage as never);
+    expect(result.length).toBe(100);
+  });
+});

--- a/packages/core/src/browser/HtmlExtractor.ts
+++ b/packages/core/src/browser/HtmlExtractor.ts
@@ -1,0 +1,45 @@
+import type { Page } from 'playwright';
+
+export class HtmlExtractor {
+  private readonly maxLength: number;
+
+  constructor(maxLength = 15_000) {
+    this.maxLength = maxLength;
+  }
+
+  async extract(page: Page): Promise<string> {
+    const rawHtml = await page.content();
+    const cleaned = HtmlExtractor.clean(rawHtml);
+
+    if (cleaned.length > this.maxLength) {
+      return cleaned.slice(0, this.maxLength);
+    }
+    return cleaned;
+  }
+
+  /**
+   * Removes scripts, styles, comments and inline style attributes
+   * to reduce token count before sending to the LLM.
+   */
+  static clean(html: string): string {
+    let result = html;
+
+    // Remove <script> tags and content
+    result = result.replace(/<script[\s\S]*?<\/script>/gi, '');
+
+    // Remove <style> tags and content
+    result = result.replace(/<style[\s\S]*?<\/style>/gi, '');
+
+    // Remove HTML comments
+    result = result.replace(/<!--[\s\S]*?-->/g, '');
+
+    // Remove inline style attributes
+    result = result.replace(/\s+style="[^"]*"/gi, '');
+    result = result.replace(/\s+style='[^']*'/gi, '');
+
+    // Collapse multiple whitespace/newlines into single space
+    result = result.replace(/\s{2,}/g, ' ');
+
+    return result.trim();
+  }
+}

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -1,1 +1,5 @@
-// Browser: Playwright wrapper for page interaction and HTML extraction.
+export { ActionExecutor } from './ActionExecutor.js';
+export type { ActionType, ExploreAction } from './ActionExecutor.js';
+export { BrowserManager } from './BrowserManager.js';
+export type { BrowserManagerOptions } from './BrowserManager.js';
+export { HtmlExtractor } from './HtmlExtractor.js';


### PR DESCRIPTION
## Summary

- Add `BrowserManager` — launches Playwright browser, manages context/page lifecycle, configurable headless/slowMo/viewport
- Add `HtmlExtractor` — extracts HTML from page, cleans scripts/styles/comments to reduce LLM tokens, truncates to maxLength
- Add `ActionExecutor` — executes 5 action types (click, fill, navigate, wait, scroll) with smart selector resolution (getByRole, getByLabel, getByTestId, getByText, CSS/XPath fallback) and descriptive errors
- 29 new tests with mocked Playwright (no real browser needed)

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 43 tests passed (14 previous + 29 new)
- [x] HtmlExtractor: script/style/comment removal, whitespace collapse, truncation, attribute preservation
- [x] ActionExecutor: all 5 actions, 6 selector types, descriptive error on failure
- [x] BrowserManager: launch/close lifecycle, idempotent launch, safe close

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)