### PR TITLE
feat(framework): ExplorationAgent (Session A orchestration)

### DIFF
--- a/packages/core/src/agents/ExplorationAgent.test.ts
+++ b/packages/core/src/agents/ExplorationAgent.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ExplorationAgent } from './ExplorationAgent.js';
+import { createAgentContext } from '../domain/AgentContext.js';
+
+function createMockAiClient(responses: Array<{
+  action: string;
+  target: string;
+  value: string | null;
+  completed: boolean;
+  analysisSummary: string;
+  tokensUsed: number;
+}>): Record<string, unknown> {
+  let callIndex = 0;
+  return {
+    createSession: vi.fn().mockResolvedValue({ sessionId: 'sess-test-001' }),
+    closeSession: vi.fn().mockResolvedValue({ closed: true }),
+    explore: vi.fn().mockImplementation(() => {
+      const response = responses[callIndex];
+      if (!response) {
+        throw new Error('No more mock responses');
+      }
+      callIndex++;
+      return Promise.resolve(response);
+    }),
+  };
+}
+
+function createMockHtmlExtractor(): Record<string, unknown> {
+  return {
+    extract: vi.fn().mockResolvedValue('<div>Mock HTML</div>'),
+  };
+}
+
+function createMockActionExecutor(): Record<string, unknown> {
+  return {
+    execute: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockPage(): Record<string, unknown> {
+  return {
+    url: vi.fn().mockReturnValue('https://example.com'),
+  };
+}
+
+function createContext(overrides: Partial<ReturnType<typeof createAgentContext>> = {}): ReturnType<typeof createAgentContext> {
+  return createAgentContext({
+    rawInput: 'Login as admin',
+    url: 'https://example.com',
+    objective: 'Validate login',
+    testName: 'login_test',
+    maxIterations: 10,
+    ...overrides,
+  });
+}
+
+describe('ExplorationAgent', () => {
+  it('completes when AI returns completed=true', async () => {
+    const aiClient = createMockAiClient([
+      { action: 'navigate', target: 'https://example.com', value: null, completed: false, analysisSummary: 'Navigate to page', tokensUsed: 100 },
+      { action: 'click', target: 'getByRole("button", { name: "Login" })', value: null, completed: true, analysisSummary: 'Login complete', tokensUsed: 120 },
+    ]);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(
+      aiClient as never,
+      extractor as never,
+      executor as never,
+      page as never,
+    );
+
+    const report = await agent.run(createContext());
+
+    expect(report.completed).toBe(true);
+    expect(report.totalRounds).toBe(2);
+    expect(report.sessionId).toBe('sess-test-001');
+    expect(report.totalTokensUsed).toBe(220);
+  });
+
+  it('executes actions from AI responses', async () => {
+    const aiClient = createMockAiClient([
+      { action: 'fill', target: 'getByLabel("Email")', value: 'admin@test.com', completed: false, analysisSummary: 'Fill email', tokensUsed: 100 },
+      { action: 'click', target: 'getByRole("button", { name: "Submit" })', value: null, completed: true, analysisSummary: 'Submit form', tokensUsed: 100 },
+    ]);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+    await agent.run(createContext());
+
+    expect(executor.execute).toHaveBeenCalledWith({
+      action: 'fill',
+      target: 'getByLabel("Email")',
+      value: 'admin@test.com',
+    });
+  });
+
+  it('does not execute action on completed round', async () => {
+    const aiClient = createMockAiClient([
+      { action: 'click', target: '#done', value: null, completed: true, analysisSummary: 'Done', tokensUsed: 50 },
+    ]);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+    await agent.run(createContext());
+
+    expect(executor.execute).not.toHaveBeenCalled();
+  });
+
+  it('throws when maxIterations reached without completing', async () => {
+    const responses = Array.from({ length: 3 }, (_, i) => ({
+      action: 'click',
+      target: `#btn-${String(i)}`,
+      value: null,
+      completed: false,
+      analysisSummary: `Round ${String(i)}`,
+      tokensUsed: 50,
+    }));
+    const aiClient = createMockAiClient(responses);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+
+    await expect(agent.run(createContext({ maxIterations: 3 }))).rejects.toThrow(
+      'Exploration did not complete within 3 iterations',
+    );
+  });
+
+  it('always closes session even on error', async () => {
+    const aiClient = createMockAiClient([]);
+    (aiClient.explore as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('AI exploded'));
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+
+    await expect(agent.run(createContext())).rejects.toThrow('AI exploded');
+    expect(aiClient.closeSession).toHaveBeenCalledWith('sess-test-001');
+  });
+
+  it('captures action errors and sends as context in next round', async () => {
+    const aiClient = createMockAiClient([
+      { action: 'click', target: '#missing', value: null, completed: false, analysisSummary: 'Try click', tokensUsed: 80 },
+      { action: 'click', target: '#found', value: null, completed: true, analysisSummary: 'Fixed', tokensUsed: 90 },
+    ]);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    // First call fails, second succeeds.
+    (executor.execute as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Element not found'))
+      .mockResolvedValueOnce(undefined);
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+    const report = await agent.run(createContext());
+
+    expect(report.rounds[0]?.actionError).toBe('Element not found');
+    expect(report.rounds[1]?.actionError).toBeUndefined();
+
+    // Check that the second explore call received the error context.
+    const secondCall = (aiClient.explore as ReturnType<typeof vi.fn>).mock.calls[1] as [string, { context: Record<string, string> }];
+    expect(secondCall[1].context.lastActionError).toBe('Element not found');
+  });
+
+  it('collects learned selectors from successful rounds', async () => {
+    const aiClient = createMockAiClient([
+      { action: 'click', target: 'getByRole("button", { name: "Login" })', value: null, completed: false, analysisSummary: 'Click login', tokensUsed: 100 },
+      { action: 'fill', target: 'getByLabel("Email")', value: 'test@test.com', completed: false, analysisSummary: 'Fill email', tokensUsed: 100 },
+      { action: 'click', target: 'getByRole("button", { name: "Submit" })', value: null, completed: true, analysisSummary: 'Submit', tokensUsed: 100 },
+    ]);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+    const report = await agent.run(createContext());
+
+    expect(report.learnedSelectors).toHaveLength(3);
+    expect(report.learnedSelectors[0]?.selector).toBe('getByRole("button", { name: "Login" })');
+    expect(report.learnedSelectors[1]?.selector).toBe('getByLabel("Email")');
+  });
+
+  it('excludes failed selectors from learned selectors', async () => {
+    const aiClient = createMockAiClient([
+      { action: 'click', target: '#broken', value: null, completed: false, analysisSummary: 'Try broken', tokensUsed: 50 },
+      { action: 'click', target: '#working', value: null, completed: true, analysisSummary: 'Works', tokensUsed: 50 },
+    ]);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    (executor.execute as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error('Not found'))
+      .mockResolvedValueOnce(undefined);
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+    const report = await agent.run(createContext());
+
+    expect(report.learnedSelectors).toHaveLength(1);
+    expect(report.learnedSelectors[0]?.selector).toBe('#working');
+  });
+
+  it('passes model from context to AI explore calls', async () => {
+    const aiClient = createMockAiClient([
+      { action: 'click', target: '#btn', value: null, completed: true, analysisSummary: 'Done', tokensUsed: 50 },
+    ]);
+    const extractor = createMockHtmlExtractor();
+    const executor = createMockActionExecutor();
+    const page = createMockPage();
+
+    const agent = new ExplorationAgent(aiClient as never, extractor as never, executor as never, page as never);
+    await agent.run(createContext({ modelFast: 'claude-haiku-4-5' }));
+
+    const call = (aiClient.explore as ReturnType<typeof vi.fn>).mock.calls[0] as [string, { model: string }];
+    expect(call[1].model).toBe('claude-haiku-4-5');
+  });
+});

--- a/packages/core/src/agents/ExplorationAgent.ts
+++ b/packages/core/src/agents/ExplorationAgent.ts
@@ -1,0 +1,122 @@
+import type { AiServiceClient } from '../ai/AiServiceClient.js';
+import type { ActionExecutor } from '../browser/ActionExecutor.js';
+import type { HtmlExtractor } from '../browser/HtmlExtractor.js';
+import type { AgentContext } from '../domain/AgentContext.js';
+import type {
+  ExplorationReport,
+  ExplorationRound,
+  LearnedSelector,
+} from '../domain/ExplorationReport.js';
+import type { Page } from 'playwright';
+
+export class ExplorationAgent {
+  constructor(
+    private readonly aiClient: AiServiceClient,
+    private readonly htmlExtractor: HtmlExtractor,
+    private readonly actionExecutor: ActionExecutor,
+    private readonly page: Page,
+  ) {}
+
+  async run(context: AgentContext): Promise<ExplorationReport> {
+    const { sessionId } = await this.aiClient.createSession();
+    const rounds: ExplorationRound[] = [];
+    let completed = false;
+    let totalTokensUsed = 0;
+    let lastActionError: string | undefined;
+
+    try {
+      for (let i = 0; i < context.maxIterations; i++) {
+        const html = await this.htmlExtractor.extract(this.page);
+
+        const exploreContext: Record<string, string> = {
+          objective: context.objective,
+          url: context.url,
+          currentUrl: this.page.url(),
+        };
+
+        if (lastActionError) {
+          exploreContext.lastActionError = lastActionError;
+        }
+
+        const response = await this.aiClient.explore(sessionId, {
+          html,
+          context: exploreContext,
+          model: context.modelFast,
+        });
+
+        totalTokensUsed += response.tokensUsed;
+
+        const round: ExplorationRound = {
+          round: i + 1,
+          action: response.action,
+          target: response.target,
+          value: response.value,
+          analysisSummary: response.analysisSummary,
+          tokensUsed: response.tokensUsed,
+        };
+
+        if (response.completed) {
+          completed = true;
+          rounds.push(round);
+          break;
+        }
+
+        // Execute action and capture errors for the next round.
+        lastActionError = undefined;
+        try {
+          await this.actionExecutor.execute({
+            action: response.action as 'click' | 'fill' | 'navigate' | 'wait' | 'scroll',
+            target: response.target,
+            value: response.value,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          lastActionError = message;
+          round.actionError = message;
+        }
+
+        rounds.push(round);
+      }
+
+      if (!completed) {
+        throw new Error(
+          `Exploration did not complete within ${String(context.maxIterations)} iterations. ` +
+          `Completed ${String(rounds.length)} rounds. Last action: "${rounds[rounds.length - 1]?.action ?? 'none'}"`,
+        );
+      }
+
+      const learnedSelectors = ExplorationAgent.extractLearnedSelectors(rounds);
+
+      return {
+        sessionId,
+        rounds,
+        learnedSelectors,
+        completed,
+        totalTokensUsed,
+        totalRounds: rounds.length,
+      };
+    } finally {
+      await this.aiClient.closeSession(sessionId).catch(() => {
+        // Best effort — don't mask the original error.
+      });
+    }
+  }
+
+  private static extractLearnedSelectors(rounds: ExplorationRound[]): LearnedSelector[] {
+    const selectors: LearnedSelector[] = [];
+    const seen = new Set<string>();
+
+    for (const round of rounds) {
+      if (!round.actionError && round.target && !seen.has(round.target)) {
+        seen.add(round.target);
+        selectors.push({
+          description: round.analysisSummary,
+          selector: round.target,
+          action: round.action,
+        });
+      }
+    }
+
+    return selectors;
+  }
+}

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,1 +1,1 @@
-// Agents: orchestrators for each pipeline phase.
+export { ExplorationAgent } from './ExplorationAgent.js';

--- a/packages/core/src/domain/AgentContext.ts
+++ b/packages/core/src/domain/AgentContext.ts
@@ -1,0 +1,61 @@
+import type { ExplorationReport } from './ExplorationReport.js';
+
+export interface GeneratedTest {
+  code: string;
+  filePath?: string;
+  tokensUsed: number;
+}
+
+export interface GeneratedArtifacts {
+  pomMd: string;
+  gherkinMd: string;
+  cucumberMd: string;
+  tokensUsed: number;
+}
+
+export interface AgentMetrics {
+  totalTokensUsed: number;
+  totalTimeMs: number;
+  explorationRounds: number;
+  generationAttempts: number;
+}
+
+export interface AgentContext {
+  rawInput: string;
+  url: string;
+  objective: string;
+  testName: string;
+  parameters: Record<string, string>;
+  modelFast: string;
+  modelStrong: string;
+  maxIterations: number;
+  maxGenerationAttempts: number;
+  explorationReport?: ExplorationReport;
+  generatedTest?: GeneratedTest;
+  generatedArtifacts?: GeneratedArtifacts;
+  generationAttempts: number;
+  metrics: AgentMetrics;
+}
+
+export function createAgentContext(partial: Partial<AgentContext> & {
+  rawInput: string;
+  url: string;
+  objective: string;
+  testName: string;
+}): AgentContext {
+  return {
+    parameters: {},
+    modelFast: 'gpt-4o-mini',
+    modelStrong: 'gpt-4o',
+    maxIterations: 25,
+    maxGenerationAttempts: 3,
+    generationAttempts: 0,
+    metrics: {
+      totalTokensUsed: 0,
+      totalTimeMs: 0,
+      explorationRounds: 0,
+      generationAttempts: 0,
+    },
+    ...partial,
+  };
+}

--- a/packages/core/src/domain/ExplorationReport.ts
+++ b/packages/core/src/domain/ExplorationReport.ts
@@ -1,0 +1,24 @@
+export interface ExplorationRound {
+  round: number;
+  action: string;
+  target: string;
+  value: string | null;
+  analysisSummary: string;
+  tokensUsed: number;
+  actionError?: string;
+}
+
+export interface LearnedSelector {
+  description: string;
+  selector: string;
+  action: string;
+}
+
+export interface ExplorationReport {
+  sessionId: string;
+  rounds: ExplorationRound[];
+  learnedSelectors: LearnedSelector[];
+  completed: boolean;
+  totalTokensUsed: number;
+  totalRounds: number;
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -1,1 +1,12 @@
-// Domain: TypeScript models (AgentContext, ExplorationReport, GeneratedTest).
+export type {
+  AgentContext,
+  AgentMetrics,
+  GeneratedArtifacts,
+  GeneratedTest,
+} from './AgentContext.js';
+export { createAgentContext } from './AgentContext.js';
+export type {
+  ExplorationReport,
+  ExplorationRound,
+  LearnedSelector,
+} from './ExplorationReport.js';


### PR DESCRIPTION
## Summary

- Add `AgentContext` — central interface flowing through the entire pipeline, with factory function `createAgentContext()`
- Add `ExplorationReport` — session A output model with rounds history, learned selectors and metrics
- Add `ExplorationAgent` — iterative loop orchestrating HTML extraction → AI exploration → action execution, with:
  - Automatic session lifecycle (try/finally guarantees session cleanup)
  - Action error capture and feedback to AI in next round (`lastActionError` context)
  - Learned selector extraction from successful rounds
  - Configurable `maxIterations` with descriptive error on timeout
- 9 unit tests with fully mocked AiServiceClient, HtmlExtractor and ActionExecutor

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — 52 tests passed (43 previous + 9 new)
- [x] Completes on `completed=true`, throws on maxIterations
- [x] Always closes session (even on error)
- [x] Captures action errors and feeds them to next AI round
- [x] Extracts learned selectors, excludes failed ones

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)