### PR TITLE
feat(framework): GenerationAgent + TestExecutor (Session B)

### DIFF
--- a/packages/core/src/agents/GenerationAgent.test.ts
+++ b/packages/core/src/agents/GenerationAgent.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { GenerationAgent } from './GenerationAgent.js';
+import { createAgentContext } from '../domain/AgentContext.js';
+import type { ExplorationReport } from '../domain/ExplorationReport.js';
+
+function createMockExplorationReport(): ExplorationReport {
+  return {
+    sessionId: 'sess-exploration-001',
+    rounds: [
+      {
+        round: 1,
+        action: 'click',
+        target: 'getByRole("button", { name: "Login" })',
+        value: null,
+        analysisSummary: 'Click login button',
+        tokensUsed: 100,
+      },
+    ],
+    learnedSelectors: [
+      {
+        description: 'Click login button',
+        selector: 'getByRole("button", { name: "Login" })',
+        action: 'click',
+      },
+    ],
+    completed: true,
+    totalTokensUsed: 100,
+    totalRounds: 1,
+  };
+}
+
+function createMockAiClient(options: {
+  generateTestResponses: Array<{ code: string; tokensUsed: number }>;
+  generateArtifactsResponse?: {
+    pomMd: string;
+    gherkinMd: string;
+    cucumberMd: string;
+    tokensUsed: number;
+  };
+}): Record<string, unknown> {
+  let sessionCounter = 0;
+  let generateTestIndex = 0;
+
+  return {
+    createSession: vi.fn().mockImplementation(() => {
+      sessionCounter++;
+      return Promise.resolve({ sessionId: `sess-gen-${String(sessionCounter).padStart(3, '0')}` });
+    }),
+    closeSession: vi.fn().mockResolvedValue({ closed: true }),
+    generateTest: vi.fn().mockImplementation(() => {
+      const response = options.generateTestResponses[generateTestIndex];
+      if (!response) {
+        throw new Error('No more mock generateTest responses');
+      }
+      generateTestIndex++;
+      return Promise.resolve(response);
+    }),
+    generateArtifacts: vi.fn().mockResolvedValue(
+      options.generateArtifactsResponse ?? {
+        pomMd: '# POM',
+        gherkinMd: '# Gherkin',
+        cucumberMd: '# Cucumber',
+        tokensUsed: 200,
+      },
+    ),
+  };
+}
+
+function createMockTestExecutor(
+  results: Array<{ passed: boolean; errorMessage?: string }>,
+): Record<string, unknown> {
+  let callIndex = 0;
+
+  return {
+    execute: vi.fn().mockImplementation((_code: string, testName: string) => {
+      const result = results[callIndex];
+      if (!result) {
+        throw new Error('No more mock executor results');
+      }
+      callIndex++;
+      return Promise.resolve({
+        ...result,
+        durationMs: 1000,
+        filePath: `/tmp/generated/${testName}.spec.ts`,
+      });
+    }),
+  };
+}
+
+function createContext(
+  overrides: Partial<ReturnType<typeof createAgentContext>> = {},
+): ReturnType<typeof createAgentContext> {
+  return createAgentContext({
+    rawInput: 'Login as admin',
+    url: 'https://example.com',
+    objective: 'Validate login',
+    testName: 'login_test',
+    explorationReport: createMockExplorationReport(),
+    ...overrides,
+  });
+}
+
+describe('GenerationAgent', () => {
+  it('generates test and artifacts on first attempt', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [{ code: 'test("login")', tokensUsed: 150 }],
+    });
+    const executor = createMockTestExecutor([{ passed: true }]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+    const result = await agent.run(createContext());
+
+    expect(result.generatedTest.code).toBe('test("login")');
+    expect(result.generatedArtifacts.pomMd).toBe('# POM');
+    expect(result.attempts).toBe(1);
+    expect(result.totalTokensUsed).toBe(350);
+  });
+
+  it('retries when test fails and succeeds on second attempt', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [
+        { code: 'test("bad")', tokensUsed: 100 },
+        { code: 'test("good")', tokensUsed: 120 },
+      ],
+    });
+    const executor = createMockTestExecutor([
+      { passed: false, errorMessage: 'Element not found' },
+      { passed: true },
+    ]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+    const result = await agent.run(createContext());
+
+    expect(result.generatedTest.code).toBe('test("good")');
+    expect(result.attempts).toBe(2);
+    expect(result.totalTokensUsed).toBe(420);
+  });
+
+  it('sends failure report on retry attempts', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [
+        { code: 'test("v1")', tokensUsed: 100 },
+        { code: 'test("v2")', tokensUsed: 100 },
+      ],
+    });
+    const executor = createMockTestExecutor([
+      { passed: false, errorMessage: 'Locator timeout' },
+      { passed: true },
+    ]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+    await agent.run(createContext());
+
+    // First call should have no failureReport.
+    const firstCall = (aiClient.generateTest as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { failureReport?: unknown },
+    ];
+    expect(firstCall[1].failureReport).toBeUndefined();
+
+    // Second call should include the failure context.
+    const secondCall = (aiClient.generateTest as ReturnType<typeof vi.fn>).mock.calls[1] as [
+      string,
+      { failureReport: { failedTest: string; errorMessage: string } },
+    ];
+    expect(secondCall[1].failureReport).toEqual({
+      failedTest: 'test("v1")',
+      errorMessage: 'Locator timeout',
+    });
+  });
+
+  it('throws after maxGenerationAttempts exhausted', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [
+        { code: 'test("v1")', tokensUsed: 50 },
+        { code: 'test("v2")', tokensUsed: 50 },
+      ],
+    });
+    const executor = createMockTestExecutor([
+      { passed: false, errorMessage: 'Error 1' },
+      { passed: false, errorMessage: 'Error 2' },
+    ]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+
+    await expect(agent.run(createContext({ maxGenerationAttempts: 2 }))).rejects.toThrow(
+      'Test generation failed after 2 attempts. Last error: Error 2',
+    );
+  });
+
+  it('always closes sessions even on error', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [{ code: 'test("x")', tokensUsed: 50 }],
+    });
+    (aiClient.generateTest as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('AI exploded'),
+    );
+    const executor = createMockTestExecutor([]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+
+    await expect(agent.run(createContext())).rejects.toThrow('AI exploded');
+    expect(aiClient.closeSession).toHaveBeenCalledWith('sess-gen-001');
+  });
+
+  it('creates fresh session for each retry attempt', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [
+        { code: 'test("v1")', tokensUsed: 50 },
+        { code: 'test("v2")', tokensUsed: 50 },
+      ],
+    });
+    const executor = createMockTestExecutor([
+      { passed: false, errorMessage: 'Failed' },
+      { passed: true },
+    ]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+    await agent.run(createContext());
+
+    expect(aiClient.createSession).toHaveBeenCalledTimes(2);
+    expect(aiClient.closeSession).toHaveBeenCalledTimes(2);
+    expect(aiClient.closeSession).toHaveBeenCalledWith('sess-gen-001');
+    expect(aiClient.closeSession).toHaveBeenCalledWith('sess-gen-002');
+  });
+
+  it('generates artifacts in the same session as successful test', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [{ code: 'test("ok")', tokensUsed: 100 }],
+    });
+    const executor = createMockTestExecutor([{ passed: true }]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+    await agent.run(createContext());
+
+    const testCall = (aiClient.generateTest as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      unknown,
+    ];
+    const artifactsCall = (aiClient.generateArtifacts as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, unknown];
+    expect(testCall[0]).toBe('sess-gen-001');
+    expect(artifactsCall[0]).toBe('sess-gen-001');
+  });
+
+  it('throws when explorationReport is missing from context', async () => {
+    const aiClient = createMockAiClient({ generateTestResponses: [] });
+    const executor = createMockTestExecutor([]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+
+    await expect(
+      agent.run(createContext({ explorationReport: undefined })),
+    ).rejects.toThrow('GenerationAgent requires an explorationReport in context');
+  });
+
+  it('passes modelStrong to AI client calls', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [{ code: 'test("ok")', tokensUsed: 100 }],
+    });
+    const executor = createMockTestExecutor([{ passed: true }]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+    await agent.run(createContext({ modelStrong: 'claude-sonnet-4-5' }));
+
+    const testCall = (aiClient.generateTest as ReturnType<typeof vi.fn>).mock.calls[0] as [
+      string,
+      { model: string },
+    ];
+    expect(testCall[1].model).toBe('claude-sonnet-4-5');
+
+    const artifactsCall = (aiClient.generateArtifacts as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, { model: string }];
+    expect(artifactsCall[1].model).toBe('claude-sonnet-4-5');
+  });
+
+  it('includes filePath in generated test result', async () => {
+    const aiClient = createMockAiClient({
+      generateTestResponses: [{ code: 'test("ok")', tokensUsed: 100 }],
+    });
+    const executor = createMockTestExecutor([{ passed: true }]);
+
+    const agent = new GenerationAgent(aiClient as never, executor as never);
+    const result = await agent.run(createContext());
+
+    expect(result.generatedTest.filePath).toBe('/tmp/generated/login_test.spec.ts');
+  });
+});

--- a/packages/core/src/agents/GenerationAgent.ts
+++ b/packages/core/src/agents/GenerationAgent.ts
@@ -1,0 +1,80 @@
+import type { AiServiceClient } from '../ai/AiServiceClient.js';
+import type { GenerateTestRequest } from '../ai/AiServiceTypes.js';
+import type { AgentContext } from '../domain/AgentContext.js';
+import type { GenerationResult } from '../domain/GenerationResult.js';
+import type { TestExecutor } from '../executor/TestExecutor.js';
+
+export class GenerationAgent {
+  constructor(
+    private readonly aiClient: AiServiceClient,
+    private readonly testExecutor: TestExecutor,
+  ) {}
+
+  async run(context: AgentContext): Promise<GenerationResult> {
+    if (!context.explorationReport) {
+      throw new Error('GenerationAgent requires an explorationReport in context');
+    }
+
+    let totalTokensUsed = 0;
+    let lastFailedCode: string | undefined;
+    let lastError: string | undefined;
+
+    for (let attempt = 1; attempt <= context.maxGenerationAttempts; attempt++) {
+      const { sessionId } = await this.aiClient.createSession();
+
+      try {
+        const request: GenerateTestRequest = {
+          explorationReport: context.explorationReport as unknown as Record<string, unknown>,
+          model: context.modelStrong,
+        };
+
+        if (lastFailedCode && lastError) {
+          request.failureReport = {
+            failedTest: lastFailedCode,
+            errorMessage: lastError,
+          };
+        }
+
+        const testResponse = await this.aiClient.generateTest(sessionId, request);
+        totalTokensUsed += testResponse.tokensUsed;
+
+        const result = await this.testExecutor.execute(testResponse.code, context.testName);
+
+        if (result.passed) {
+          const artifactsResponse = await this.aiClient.generateArtifacts(sessionId, {
+            model: context.modelStrong,
+          });
+          totalTokensUsed += artifactsResponse.tokensUsed;
+
+          return {
+            generatedTest: {
+              code: testResponse.code,
+              filePath: result.filePath,
+              tokensUsed: testResponse.tokensUsed,
+            },
+            generatedArtifacts: {
+              pomMd: artifactsResponse.pomMd,
+              gherkinMd: artifactsResponse.gherkinMd,
+              cucumberMd: artifactsResponse.cucumberMd,
+              tokensUsed: artifactsResponse.tokensUsed,
+            },
+            totalTokensUsed,
+            attempts: attempt,
+          };
+        }
+
+        lastFailedCode = testResponse.code;
+        lastError = result.errorMessage ?? 'Test failed with unknown error';
+      } finally {
+        await this.aiClient.closeSession(sessionId).catch(() => {
+          // Best effort — don't mask the original error.
+        });
+      }
+    }
+
+    throw new Error(
+      `Test generation failed after ${String(context.maxGenerationAttempts)} attempts. ` +
+      `Last error: ${lastError ?? 'unknown'}`,
+    );
+  }
+}

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,1 +1,2 @@
 export { ExplorationAgent } from './ExplorationAgent.js';
+export { GenerationAgent } from './GenerationAgent.js';

--- a/packages/core/src/domain/GenerationResult.ts
+++ b/packages/core/src/domain/GenerationResult.ts
@@ -1,0 +1,8 @@
+import type { GeneratedArtifacts, GeneratedTest } from './AgentContext.js';
+
+export interface GenerationResult {
+  generatedTest: GeneratedTest;
+  generatedArtifacts: GeneratedArtifacts;
+  totalTokensUsed: number;
+  attempts: number;
+}

--- a/packages/core/src/domain/index.ts
+++ b/packages/core/src/domain/index.ts
@@ -10,3 +10,4 @@ export type {
   ExplorationRound,
   LearnedSelector,
 } from './ExplorationReport.js';
+export type { GenerationResult } from './GenerationResult.js';

--- a/packages/core/src/executor/TestExecutor.test.ts
+++ b/packages/core/src/executor/TestExecutor.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+import { execFile } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { TestExecutor } from './TestExecutor.js';
+
+const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
+const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
+const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
+
+type ExecFileCallback = (error: Error | null, stdout: string, stderr: string) => void;
+
+function mockExecSuccess(stdout = 'Tests passed'): void {
+  mockExecFile.mockImplementation(
+    (_file: string, _args: string[], _opts: unknown, callback: ExecFileCallback) => {
+      callback(null, stdout, '');
+    },
+  );
+}
+
+function mockExecFailure(stderr: string, stdout = ''): void {
+  mockExecFile.mockImplementation(
+    (_file: string, _args: string[], _opts: unknown, callback: ExecFileCallback) => {
+      const error = new Error('Process exited with code 1');
+      callback(error, stdout, stderr);
+    },
+  );
+}
+
+describe('TestExecutor', () => {
+  let executor: TestExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new TestExecutor('/tmp/test-output');
+  });
+
+  it('creates output directory before writing', async () => {
+    mockExecSuccess();
+    await executor.execute('test code', 'my_test');
+
+    expect(mockMkdir).toHaveBeenCalledWith('/tmp/test-output', { recursive: true });
+  });
+
+  it('writes test code to the correct file path', async () => {
+    mockExecSuccess();
+    await executor.execute('test("hello")', 'login_test');
+
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      '/tmp/test-output/login_test.spec.ts',
+      'test("hello")',
+      'utf-8',
+    );
+  });
+
+  it('returns passed=true when playwright exits successfully', async () => {
+    mockExecSuccess();
+    const result = await executor.execute('test code', 'my_test');
+
+    expect(result.passed).toBe(true);
+    expect(result.errorMessage).toBeUndefined();
+    expect(result.filePath).toBe('/tmp/test-output/my_test.spec.ts');
+  });
+
+  it('returns passed=false with error when playwright fails', async () => {
+    mockExecFailure('Error: locator.click: Target closed');
+    const result = await executor.execute('test code', 'my_test');
+
+    expect(result.passed).toBe(false);
+    expect(result.errorMessage).toBe('Error: locator.click: Target closed');
+    expect(result.filePath).toBe('/tmp/test-output/my_test.spec.ts');
+  });
+
+  it('combines stderr and stdout in error message', async () => {
+    mockExecFailure('stderr output', 'stdout output');
+    const result = await executor.execute('test code', 'my_test');
+
+    expect(result.passed).toBe(false);
+    expect(result.errorMessage).toBe('stderr output\nstdout output');
+  });
+
+  it('uses error.message as fallback when no output', async () => {
+    mockExecFile.mockImplementation(
+      (_file: string, _args: string[], _opts: unknown, callback: ExecFileCallback) => {
+        const error = new Error('spawn ENOENT');
+        callback(error, '', '');
+      },
+    );
+    const result = await executor.execute('test code', 'my_test');
+
+    expect(result.passed).toBe(false);
+    expect(result.errorMessage).toBe('spawn ENOENT');
+  });
+
+  it('measures execution duration', async () => {
+    mockExecSuccess();
+    const result = await executor.execute('test code', 'my_test');
+
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('calls npx playwright test with correct arguments', async () => {
+    mockExecSuccess();
+    await executor.execute('test code', 'my_test');
+
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'npx',
+      ['playwright', 'test', '/tmp/test-output/my_test.spec.ts', '--reporter=line'],
+      { timeout: 120_000 },
+      expect.any(Function),
+    );
+  });
+});

--- a/packages/core/src/executor/TestExecutor.ts
+++ b/packages/core/src/executor/TestExecutor.ts
@@ -1,0 +1,58 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+export interface ExecutionResult {
+  passed: boolean;
+  errorMessage?: string;
+  durationMs: number;
+  filePath: string;
+}
+
+export class TestExecutor {
+  constructor(private readonly outputDir: string) {}
+
+  async execute(code: string, testName: string): Promise<ExecutionResult> {
+    const filePath = join(this.outputDir, `${testName}.spec.ts`);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, code, 'utf-8');
+
+    const start = Date.now();
+
+    try {
+      await this.runPlaywright(filePath);
+      return { passed: true, durationMs: Date.now() - start, filePath };
+    } catch (error: unknown) {
+      const durationMs = Date.now() - start;
+      const execError = error as { stderr?: string; stdout?: string; message: string };
+      const output = [execError.stderr, execError.stdout]
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+      return {
+        passed: false,
+        errorMessage: output || execError.message,
+        durationMs,
+        filePath,
+      };
+    }
+  }
+
+  private runPlaywright(filePath: string): Promise<{ stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+      execFileCb(
+        'npx',
+        ['playwright', 'test', filePath, '--reporter=line'],
+        { timeout: 120_000 },
+        (error, stdout, stderr) => {
+          if (error) {
+            Object.assign(error, { stdout, stderr });
+            reject(error as Error);
+          } else {
+            resolve({ stdout, stderr });
+          }
+        },
+      );
+    });
+  }
+}

--- a/packages/core/src/executor/index.ts
+++ b/packages/core/src/executor/index.ts
@@ -1,1 +1,2 @@
-// Executor: runs generated tests via Playwright test runner.
+export { TestExecutor } from './TestExecutor.js';
+export type { ExecutionResult } from './TestExecutor.js';


### PR DESCRIPTION
## Summary

- **GenerationAgent**: Orchestrates Session B with retry loop — generates test via AI, executes it, and on success generates artifacts (POM, Gherkin, Cucumber) in the same session. On failure, opens a fresh session with full exploration report + failure context
- **TestExecutor**: Writes generated `.spec.ts` to disk and executes via `npx playwright test`, returning `ExecutionResult` with pass/fail, error message and duration
- **GenerationResult**: New domain type for the generation pipeline output
- **18 new tests** (10 GenerationAgent + 8 TestExecutor), 70 total passing

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint src` passes
- [x] `vitest run` — 70/70 tests passing

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)