### PR TITLE
[T12] Add ProjectConfig, SetupManager and SetupAgent

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,5 +39,8 @@
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.20.0",
     "vitest": "^3.0.0"
+  },
+  "dependencies": {
+    "yaml": "^2.8.2"
   }
 }

--- a/packages/core/src/agents/SetupAgent.test.ts
+++ b/packages/core/src/agents/SetupAgent.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAgentContext } from '../domain/AgentContext.js';
+import { SetupAgent } from './SetupAgent.js';
+
+function createContext(overrides: Partial<ReturnType<typeof createAgentContext>> = {}): ReturnType<typeof createAgentContext> {
+  return createAgentContext({
+    rawInput: 'Login to dashboard con usuario admin',
+    url: 'https://example.com',
+    objective: 'Validate dashboard',
+    testName: 'dashboard_test',
+    ...overrides,
+  });
+}
+
+function createMockSetupManager(options: {
+  users?: Array<{ name: string; email?: string; password?: string; role?: string; authFlow: string }>;
+  defaultEnv?: string;
+} = {}): Record<string, unknown> {
+  const users = options.users ?? [
+    { name: 'admin', email: 'admin@test.com', password: 'pass', role: 'admin', authFlow: 'login_form' },
+  ];
+
+  return {
+    findUser: vi.fn().mockImplementation((name: string) =>
+      users.find((u) => u.name === name),
+    ),
+    loadSetup: vi.fn().mockImplementation((envName: string, userName: string) => ({
+      environment: { name: envName, baseUrl: `https://${envName}.example.com` },
+      user: users.find((u) => u.name === userName),
+    })),
+    authenticate: vi.fn().mockResolvedValue(undefined),
+    findEnvironmentForUser: vi.fn().mockReturnValue(options.defaultEnv ?? 'staging'),
+  };
+}
+
+describe('SetupAgent', () => {
+  it('returns context unchanged when no user is detected', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext();
+
+    const result = await agent.run(context);
+
+    expect(result.authenticated).toBe(false);
+    expect(result.context).toBe(context);
+    expect(manager.authenticate).not.toHaveBeenCalled();
+  });
+
+  it('returns context unchanged when detected user is not in config', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext();
+
+    const result = await agent.run(context, 'ghost');
+
+    expect(result.authenticated).toBe(false);
+    expect(result.context).toBe(context);
+  });
+
+  it('authenticates and updates context when user is found', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext();
+
+    const result = await agent.run(context, 'admin');
+
+    expect(result.authenticated).toBe(true);
+    expect(manager.loadSetup).toHaveBeenCalledWith('staging', 'admin');
+    expect(manager.authenticate).toHaveBeenCalled();
+  });
+
+  it('cleans user reference from rawInput (Spanish "con usuario")', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext({ rawInput: 'Login to dashboard con usuario admin' });
+
+    const result = await agent.run(context, 'admin');
+
+    expect(result.context.rawInput).toBe('Login to dashboard');
+  });
+
+  it('cleans user reference from rawInput (Spanish "como")', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext({ rawInput: 'Navegar al panel como admin' });
+
+    const result = await agent.run(context, 'admin');
+
+    expect(result.context.rawInput).toBe('Navegar al panel');
+  });
+
+  it('cleans user reference from rawInput (English "as")', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext({ rawInput: 'Navigate to dashboard as admin' });
+
+    const result = await agent.run(context, 'admin');
+
+    expect(result.context.rawInput).toBe('Navigate to dashboard');
+  });
+
+  it('cleans user reference from rawInput (English "with user")', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext({ rawInput: 'Check settings with user admin' });
+
+    const result = await agent.run(context, 'admin');
+
+    expect(result.context.rawInput).toBe('Check settings');
+  });
+
+  it('populates setup field in context with environment and user', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext();
+
+    const result = await agent.run(context, 'admin');
+
+    expect(result.context.setup).toBeDefined();
+    expect(result.context.setup?.environment.name).toBe('staging');
+    expect(result.context.setup?.user.name).toBe('admin');
+  });
+
+  it('uses explicit environment when provided', async () => {
+    const manager = createMockSetupManager();
+    const agent = new SetupAgent(manager as never);
+    const context = createContext();
+
+    await agent.run(context, 'admin', 'production');
+
+    expect(manager.loadSetup).toHaveBeenCalledWith('production', 'admin');
+    expect(manager.findEnvironmentForUser).not.toHaveBeenCalled();
+  });
+
+  it('uses default environment from setupManager when not provided', async () => {
+    const manager = createMockSetupManager({ defaultEnv: 'dev' });
+    const agent = new SetupAgent(manager as never);
+    const context = createContext();
+
+    await agent.run(context, 'admin');
+
+    expect(manager.findEnvironmentForUser).toHaveBeenCalledWith('admin');
+    expect(manager.loadSetup).toHaveBeenCalledWith('dev', 'admin');
+  });
+
+  it('returns unauthenticated when no environment can be resolved', async () => {
+    const manager = createMockSetupManager();
+    (manager.findEnvironmentForUser as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    const agent = new SetupAgent(manager as never);
+    const context = createContext();
+
+    const result = await agent.run(context, 'admin');
+
+    expect(result.authenticated).toBe(false);
+    expect(result.context).toBe(context);
+  });
+});
+
+describe('SetupAgent.removeUserReference', () => {
+  it('removes "con usuario X" pattern', () => {
+    expect(SetupAgent.removeUserReference('Haz login con usuario admin', 'admin')).toBe('Haz login');
+  });
+
+  it('removes "como X" pattern', () => {
+    expect(SetupAgent.removeUserReference('Accede como viewer', 'viewer')).toBe('Accede');
+  });
+
+  it('removes "as X" pattern', () => {
+    expect(SetupAgent.removeUserReference('Login as admin', 'admin')).toBe('Login');
+  });
+
+  it('removes "with user X" pattern', () => {
+    expect(SetupAgent.removeUserReference('Check page with user admin', 'admin')).toBe('Check page');
+  });
+
+  it('removes "using user X" pattern', () => {
+    expect(SetupAgent.removeUserReference('Test using user admin', 'admin')).toBe('Test');
+  });
+
+  it('returns input unchanged when no pattern matches', () => {
+    expect(SetupAgent.removeUserReference('Navigate to settings', 'admin')).toBe('Navigate to settings');
+  });
+
+  it('is case insensitive', () => {
+    expect(SetupAgent.removeUserReference('Login AS Admin', 'admin')).toBe('Login');
+  });
+});

--- a/packages/core/src/agents/SetupAgent.ts
+++ b/packages/core/src/agents/SetupAgent.ts
@@ -1,0 +1,64 @@
+import type { AgentContext } from '../domain/AgentContext.js';
+import type { SetupManager } from '../config/SetupManager.js';
+
+export interface SetupResult {
+  context: AgentContext;
+  authenticated: boolean;
+}
+
+export class SetupAgent {
+  constructor(private readonly setupManager: SetupManager) {}
+
+  async run(
+    context: AgentContext,
+    detectedUser?: string,
+    environmentName?: string,
+  ): Promise<SetupResult> {
+    if (!detectedUser) {
+      return { context, authenticated: false };
+    }
+
+    const user = this.setupManager.findUser(detectedUser);
+    if (!user) {
+      return { context, authenticated: false };
+    }
+
+    const envName = environmentName ?? this.setupManager.findEnvironmentForUser(detectedUser);
+    if (!envName) {
+      return { context, authenticated: false };
+    }
+
+    const setup = this.setupManager.loadSetup(envName, detectedUser);
+    await this.setupManager.authenticate(setup);
+
+    const cleanedInput = SetupAgent.removeUserReference(context.rawInput, detectedUser);
+
+    const updatedContext: AgentContext = {
+      ...context,
+      rawInput: cleanedInput,
+      setup: {
+        environment: setup.environment,
+        user: setup.user,
+      },
+    };
+
+    return { context: updatedContext, authenticated: true };
+  }
+
+  static removeUserReference(rawInput: string, userName: string): string {
+    const patterns = [
+      new RegExp(`\\s+con usuario\\s+${userName}`, 'gi'),
+      new RegExp(`\\s+como\\s+${userName}`, 'gi'),
+      new RegExp(`\\s+as\\s+${userName}`, 'gi'),
+      new RegExp(`\\s+with user\\s+${userName}`, 'gi'),
+      new RegExp(`\\s+using user\\s+${userName}`, 'gi'),
+    ];
+
+    let result = rawInput;
+    for (const pattern of patterns) {
+      result = result.replace(pattern, '');
+    }
+    return result.trim();
+  }
+
+}

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,2 +1,4 @@
 export { ExplorationAgent } from './ExplorationAgent.js';
 export { GenerationAgent } from './GenerationAgent.js';
+export { SetupAgent } from './SetupAgent.js';
+export type { SetupResult } from './SetupAgent.js';

--- a/packages/core/src/config/ProjectConfig.test.ts
+++ b/packages/core/src/config/ProjectConfig.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from 'node:fs/promises';
+
+import {
+  loadProjectConfig,
+  ProjectConfigError,
+  resolveEnvVars,
+} from './ProjectConfig.js';
+
+const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+
+const VALID_YAML = `
+project:
+  name: my-app
+
+environments:
+  - name: staging
+    base_url: https://staging.example.com
+  - name: production
+    base_url: https://prod.example.com
+    cookies: /path/to/cookies.json
+
+users:
+  - name: admin
+    email: admin@test.com
+    password: secret123
+    role: administrator
+    auth_flow: login_form
+  - name: viewer
+    auth_flow: cookie_injection
+
+setup_combinations:
+  - environment: staging
+    users: [admin, viewer]
+`;
+
+const MINIMAL_YAML = `
+project:
+  name: minimal-app
+`;
+
+describe('loadProjectConfig', () => {
+  it('parses a valid YAML config', async () => {
+    mockReadFile.mockResolvedValue(VALID_YAML);
+
+    const config = await loadProjectConfig('/fake/ppia.yaml');
+
+    expect(config.projectName).toBe('my-app');
+    expect(config.environments).toHaveLength(2);
+    expect(config.environments[0]).toEqual({
+      name: 'staging',
+      baseUrl: 'https://staging.example.com',
+      cookies: undefined,
+    });
+    expect(config.environments[1]).toEqual({
+      name: 'production',
+      baseUrl: 'https://prod.example.com',
+      cookies: '/path/to/cookies.json',
+    });
+    expect(config.users).toHaveLength(2);
+    expect(config.users[0]).toEqual({
+      name: 'admin',
+      email: 'admin@test.com',
+      password: 'secret123',
+      role: 'administrator',
+      authFlow: 'login_form',
+    });
+    expect(config.users[1]).toEqual({
+      name: 'viewer',
+      email: undefined,
+      password: undefined,
+      role: undefined,
+      authFlow: 'cookie_injection',
+    });
+    expect(config.setupCombinations).toHaveLength(1);
+    expect(config.setupCombinations[0]).toEqual({
+      environment: 'staging',
+      users: ['admin', 'viewer'],
+    });
+  });
+
+  it('parses a minimal YAML with only project.name', async () => {
+    mockReadFile.mockResolvedValue(MINIMAL_YAML);
+
+    const config = await loadProjectConfig('/fake/ppia.yaml');
+
+    expect(config.projectName).toBe('minimal-app');
+    expect(config.environments).toEqual([]);
+    expect(config.users).toEqual([]);
+    expect(config.setupCombinations).toEqual([]);
+  });
+
+  it('resolves environment variables in values', async () => {
+    process.env.TEST_BASE_URL = 'https://env.example.com';
+    process.env.TEST_PASSWORD = 'env-pass';
+
+    const yaml = `
+project:
+  name: env-app
+environments:
+  - name: test
+    base_url: \${TEST_BASE_URL}
+users:
+  - name: admin
+    password: \${TEST_PASSWORD}
+    auth_flow: login_form
+`;
+    mockReadFile.mockResolvedValue(yaml);
+
+    const config = await loadProjectConfig('/fake/ppia.yaml');
+
+    expect(config.environments[0]?.baseUrl).toBe('https://env.example.com');
+    expect(config.users[0]?.password).toBe('env-pass');
+
+    delete process.env.TEST_BASE_URL;
+    delete process.env.TEST_PASSWORD;
+  });
+
+  it('throws when an env var is missing', async () => {
+    const yaml = `
+project:
+  name: missing-env
+environments:
+  - name: test
+    base_url: \${NONEXISTENT_VAR}
+`;
+    mockReadFile.mockResolvedValue(yaml);
+
+    await expect(loadProjectConfig('/fake/ppia.yaml')).rejects.toThrow(
+      'Environment variable "NONEXISTENT_VAR" is not defined',
+    );
+  });
+
+  it('throws on invalid YAML syntax', async () => {
+    mockReadFile.mockResolvedValue('{ invalid yaml: [}');
+
+    await expect(loadProjectConfig('/fake/ppia.yaml')).rejects.toThrow('Invalid YAML syntax');
+  });
+
+  it('throws when file is not found', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+    await expect(loadProjectConfig('/missing/ppia.yaml')).rejects.toThrow(
+      'Config file not found: /missing/ppia.yaml',
+    );
+    await expect(loadProjectConfig('/missing/ppia.yaml')).rejects.toBeInstanceOf(
+      ProjectConfigError,
+    );
+  });
+
+  it('throws when project.name is missing', async () => {
+    mockReadFile.mockResolvedValue('project:\n  version: 1');
+
+    await expect(loadProjectConfig('/fake/ppia.yaml')).rejects.toThrow(
+      'project.name is required',
+    );
+  });
+
+  it('throws on invalid auth_flow', async () => {
+    const yaml = `
+project:
+  name: bad-auth
+users:
+  - name: admin
+    auth_flow: magic_link
+`;
+    mockReadFile.mockResolvedValue(yaml);
+
+    await expect(loadProjectConfig('/fake/ppia.yaml')).rejects.toThrow(
+      'users[0].auth_flow must be one of: login_form, cookie_injection. Got: "magic_link"',
+    );
+  });
+
+  it('throws when setup_combination references unknown environment', async () => {
+    const yaml = `
+project:
+  name: bad-combo
+environments:
+  - name: staging
+    base_url: https://staging.example.com
+users:
+  - name: admin
+    auth_flow: login_form
+setup_combinations:
+  - environment: production
+    users: [admin]
+`;
+    mockReadFile.mockResolvedValue(yaml);
+
+    await expect(loadProjectConfig('/fake/ppia.yaml')).rejects.toThrow(
+      'setup_combinations[0].environment "production" does not reference a defined environment',
+    );
+  });
+
+  it('throws when setup_combination references unknown user', async () => {
+    const yaml = `
+project:
+  name: bad-combo
+environments:
+  - name: staging
+    base_url: https://staging.example.com
+users:
+  - name: admin
+    auth_flow: login_form
+setup_combinations:
+  - environment: staging
+    users: [admin, ghost]
+`;
+    mockReadFile.mockResolvedValue(yaml);
+
+    await expect(loadProjectConfig('/fake/ppia.yaml')).rejects.toThrow(
+      'setup_combinations[0].users contains unknown user "ghost"',
+    );
+  });
+});
+
+describe('resolveEnvVars', () => {
+  it('replaces ${VAR} with process.env value', () => {
+    process.env.RESOLVE_TEST = 'hello';
+    expect(resolveEnvVars('prefix-${RESOLVE_TEST}-suffix')).toBe('prefix-hello-suffix');
+    delete process.env.RESOLVE_TEST;
+  });
+
+  it('replaces multiple vars in one string', () => {
+    process.env.A_VAR = 'a';
+    process.env.B_VAR = 'b';
+    expect(resolveEnvVars('${A_VAR}/${B_VAR}')).toBe('a/b');
+    delete process.env.A_VAR;
+    delete process.env.B_VAR;
+  });
+
+  it('returns string unchanged when no vars present', () => {
+    expect(resolveEnvVars('no-vars-here')).toBe('no-vars-here');
+  });
+
+  it('throws for undefined env var', () => {
+    expect(() => resolveEnvVars('${DEFINITELY_MISSING}')).toThrow(
+      'Environment variable "DEFINITELY_MISSING" is not defined',
+    );
+  });
+});

--- a/packages/core/src/config/ProjectConfig.ts
+++ b/packages/core/src/config/ProjectConfig.ts
@@ -1,0 +1,222 @@
+import { readFile } from 'node:fs/promises';
+
+import { parse } from 'yaml';
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface EnvironmentConfig {
+  name: string;
+  baseUrl: string;
+  cookies?: string;
+}
+
+export type AuthFlow = 'login_form' | 'cookie_injection';
+
+export interface UserConfig {
+  name: string;
+  email?: string;
+  password?: string;
+  role?: string;
+  authFlow: AuthFlow;
+}
+
+export interface SetupCombination {
+  environment: string;
+  users: string[];
+}
+
+export interface ProjectConfig {
+  projectName: string;
+  environments: EnvironmentConfig[];
+  users: UserConfig[];
+  setupCombinations: SetupCombination[];
+}
+
+export class ProjectConfigError extends Error {
+  constructor(
+    message: string,
+    public readonly field?: string,
+  ) {
+    super(message);
+    this.name = 'ProjectConfigError';
+  }
+}
+
+// ── Raw YAML shapes ────────────────────────────────────────────────────
+
+interface RawEnvironment {
+  name?: unknown;
+  base_url?: unknown;
+  cookies?: unknown;
+}
+
+interface RawUser {
+  name?: unknown;
+  email?: unknown;
+  password?: unknown;
+  role?: unknown;
+  auth_flow?: unknown;
+}
+
+interface RawCombination {
+  environment?: unknown;
+  users?: unknown;
+}
+
+interface RawConfig {
+  project?: { name?: unknown };
+  environments?: unknown[];
+  users?: unknown[];
+  setup_combinations?: unknown[];
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+const VALID_AUTH_FLOWS: readonly AuthFlow[] = ['login_form', 'cookie_injection'];
+
+export function resolveEnvVars(value: string): string {
+  return value.replace(/\$\{([^}]+)\}/g, (match, varName: string) => {
+    const resolved = process.env[varName];
+    if (resolved === undefined) {
+      throw new ProjectConfigError(
+        `Environment variable "${varName}" is not defined (referenced in "${match}")`,
+      );
+    }
+    return resolved;
+  });
+}
+
+function resolveOptionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? resolveEnvVars(value) : undefined;
+}
+
+function parseEnvironment(raw: RawEnvironment, index: number): EnvironmentConfig {
+  if (typeof raw.name !== 'string' || raw.name.length === 0) {
+    throw new ProjectConfigError(
+      `environments[${String(index)}].name is required and must be a non-empty string`,
+      `environments[${String(index)}].name`,
+    );
+  }
+  if (typeof raw.base_url !== 'string' || raw.base_url.length === 0) {
+    throw new ProjectConfigError(
+      `environments[${String(index)}].base_url is required and must be a non-empty string`,
+      `environments[${String(index)}].base_url`,
+    );
+  }
+  return {
+    name: raw.name,
+    baseUrl: resolveEnvVars(raw.base_url),
+    cookies: resolveOptionalString(raw.cookies),
+  };
+}
+
+function parseUser(raw: RawUser, index: number): UserConfig {
+  if (typeof raw.name !== 'string' || raw.name.length === 0) {
+    throw new ProjectConfigError(
+      `users[${String(index)}].name is required and must be a non-empty string`,
+      `users[${String(index)}].name`,
+    );
+  }
+  if (typeof raw.auth_flow !== 'string' || !VALID_AUTH_FLOWS.includes(raw.auth_flow as AuthFlow)) {
+    throw new ProjectConfigError(
+      `users[${String(index)}].auth_flow must be one of: ${VALID_AUTH_FLOWS.join(', ')}. Got: "${String(raw.auth_flow)}"`,
+      `users[${String(index)}].auth_flow`,
+    );
+  }
+  return {
+    name: raw.name,
+    email: resolveOptionalString(raw.email),
+    password: resolveOptionalString(raw.password),
+    role: typeof raw.role === 'string' ? raw.role : undefined,
+    authFlow: raw.auth_flow as AuthFlow,
+  };
+}
+
+function parseCombination(
+  raw: RawCombination,
+  index: number,
+  environmentNames: Set<string>,
+  userNames: Set<string>,
+): SetupCombination {
+  if (typeof raw.environment !== 'string' || !environmentNames.has(raw.environment)) {
+    throw new ProjectConfigError(
+      `setup_combinations[${String(index)}].environment "${String(raw.environment)}" does not reference a defined environment`,
+      `setup_combinations[${String(index)}].environment`,
+    );
+  }
+  if (!Array.isArray(raw.users) || raw.users.length === 0) {
+    throw new ProjectConfigError(
+      `setup_combinations[${String(index)}].users must be a non-empty array`,
+      `setup_combinations[${String(index)}].users`,
+    );
+  }
+  for (const userName of raw.users) {
+    if (typeof userName !== 'string' || !userNames.has(userName)) {
+      throw new ProjectConfigError(
+        `setup_combinations[${String(index)}].users contains unknown user "${String(userName)}"`,
+        `setup_combinations[${String(index)}].users`,
+      );
+    }
+  }
+  return {
+    environment: raw.environment,
+    users: raw.users as string[],
+  };
+}
+
+// ── Main ───────────────────────────────────────────────────────────────
+
+export async function loadProjectConfig(filePath: string): Promise<ProjectConfig> {
+  let content: string;
+  try {
+    content = await readFile(filePath, 'utf-8');
+  } catch {
+    throw new ProjectConfigError(`Config file not found: ${filePath}`, 'file');
+  }
+
+  let raw: unknown;
+  try {
+    raw = parse(content);
+  } catch {
+    throw new ProjectConfigError('Invalid YAML syntax', 'file');
+  }
+
+  const config = raw as RawConfig | null;
+
+  if (!config || typeof config !== 'object') {
+    throw new ProjectConfigError('Config file is empty or not an object', 'file');
+  }
+
+  const projectName = config.project?.name;
+  if (typeof projectName !== 'string' || projectName.length === 0) {
+    throw new ProjectConfigError(
+      'project.name is required and must be a non-empty string',
+      'project.name',
+    );
+  }
+
+  const rawEnvironments = Array.isArray(config.environments) ? config.environments : [];
+  const rawUsers = Array.isArray(config.users) ? config.users : [];
+  const rawCombinations = Array.isArray(config.setup_combinations) ? config.setup_combinations : [];
+
+  const environments = rawEnvironments.map(
+    (env, i) => parseEnvironment(env as RawEnvironment, i),
+  );
+  const users = rawUsers.map(
+    (user, i) => parseUser(user as RawUser, i),
+  );
+
+  const environmentNames = new Set(environments.map((e) => e.name));
+  const userNames = new Set(users.map((u) => u.name));
+
+  const setupCombinations = rawCombinations.map(
+    (combo, i) => parseCombination(combo as RawCombination, i, environmentNames, userNames),
+  );
+
+  return {
+    projectName,
+    environments,
+    users,
+    setupCombinations,
+  };
+}

--- a/packages/core/src/config/SetupManager.test.ts
+++ b/packages/core/src/config/SetupManager.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+}));
+
+import { readFile } from 'node:fs/promises';
+
+import type { ProjectConfig } from './ProjectConfig.js';
+import { SetupManager } from './SetupManager.js';
+
+const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+
+function createConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    projectName: 'test-app',
+    environments: [
+      { name: 'staging', baseUrl: 'https://staging.example.com' },
+      { name: 'production', baseUrl: 'https://prod.example.com', cookies: '/path/to/cookies.json' },
+    ],
+    users: [
+      { name: 'admin', email: 'admin@test.com', password: 'pass123', role: 'admin', authFlow: 'login_form' },
+      { name: 'viewer', authFlow: 'cookie_injection' },
+    ],
+    setupCombinations: [
+      { environment: 'staging', users: ['admin', 'viewer'] },
+    ],
+    ...overrides,
+  };
+}
+
+function createMockActionExecutor(): Record<string, unknown> {
+  return {
+    execute: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createMockPage(): Record<string, unknown> {
+  const addCookies = vi.fn().mockResolvedValue(undefined);
+  return {
+    context: vi.fn().mockReturnValue({ addCookies }),
+    goto: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('SetupManager', () => {
+  describe('findUser', () => {
+    it('returns user when found', () => {
+      const manager = new SetupManager(
+        createConfig(),
+        createMockActionExecutor() as never,
+        createMockPage() as never,
+      );
+
+      const user = manager.findUser('admin');
+
+      expect(user).toBeDefined();
+      expect(user?.name).toBe('admin');
+      expect(user?.email).toBe('admin@test.com');
+    });
+
+    it('returns undefined when user not found', () => {
+      const manager = new SetupManager(
+        createConfig(),
+        createMockActionExecutor() as never,
+        createMockPage() as never,
+      );
+
+      expect(manager.findUser('ghost')).toBeUndefined();
+    });
+  });
+
+  describe('loadSetup', () => {
+    it('resolves a valid environment + user combination', () => {
+      const manager = new SetupManager(
+        createConfig(),
+        createMockActionExecutor() as never,
+        createMockPage() as never,
+      );
+
+      const setup = manager.loadSetup('staging', 'admin');
+
+      expect(setup.environment.name).toBe('staging');
+      expect(setup.environment.baseUrl).toBe('https://staging.example.com');
+      expect(setup.user.name).toBe('admin');
+    });
+
+    it('throws when environment is not found', () => {
+      const manager = new SetupManager(
+        createConfig(),
+        createMockActionExecutor() as never,
+        createMockPage() as never,
+      );
+
+      expect(() => manager.loadSetup('unknown', 'admin')).toThrow(
+        'Environment "unknown" not found in project config',
+      );
+    });
+
+    it('throws when user is not found', () => {
+      const manager = new SetupManager(
+        createConfig(),
+        createMockActionExecutor() as never,
+        createMockPage() as never,
+      );
+
+      expect(() => manager.loadSetup('staging', 'ghost')).toThrow(
+        'User "ghost" not found in project config',
+      );
+    });
+  });
+
+  describe('authenticate', () => {
+    it('executes login_form sequence: navigate → fill email → fill password → click submit', async () => {
+      const executor = createMockActionExecutor();
+      const page = createMockPage();
+      const manager = new SetupManager(createConfig(), executor as never, page as never);
+      const setup = manager.loadSetup('staging', 'admin');
+
+      await manager.authenticate(setup);
+
+      const calls = (executor.execute as ReturnType<typeof vi.fn>).mock.calls as Array<[{ action: string; target: string; value: string | null }]>;
+      expect(calls).toHaveLength(4);
+      expect(calls[0]?.[0]).toEqual({ action: 'navigate', target: 'https://staging.example.com', value: null });
+      expect(calls[1]?.[0]).toEqual({ action: 'fill', target: 'getByLabel("Email")', value: 'admin@test.com' });
+      expect(calls[2]?.[0]).toEqual({ action: 'fill', target: 'getByLabel("Password")', value: 'pass123' });
+      expect(calls[3]?.[0]).toEqual({ action: 'click', target: 'getByRole("button", { name: "Submit" })', value: null });
+    });
+
+    it('executes cookie_injection: reads cookies file → addCookies → navigate', async () => {
+      const executor = createMockActionExecutor();
+      const page = createMockPage();
+      const manager = new SetupManager(createConfig(), executor as never, page as never);
+
+      const setup = manager.loadSetup('production', 'viewer');
+
+      const mockCookies = [{ name: 'session', value: 'abc123', domain: '.example.com', path: '/' }];
+
+      mockReadFile.mockResolvedValue(JSON.stringify(mockCookies));
+
+      await manager.authenticate(setup);
+
+      const context = (page.context as ReturnType<typeof vi.fn>)() as { addCookies: ReturnType<typeof vi.fn> };
+      expect(context.addCookies).toHaveBeenCalledWith(mockCookies);
+
+      const executorCalls = (executor.execute as ReturnType<typeof vi.fn>).mock.calls as Array<[{ action: string; target: string }]>;
+      expect(executorCalls).toHaveLength(1);
+      expect(executorCalls[0]?.[0]?.action).toBe('navigate');
+      expect(executorCalls[0]?.[0]?.target).toBe('https://prod.example.com');
+    });
+
+    it('throws when cookie_injection has no cookies path', async () => {
+      const config = createConfig({
+        environments: [
+          { name: 'no-cookies', baseUrl: 'https://example.com' },
+        ],
+        users: [
+          { name: 'viewer', authFlow: 'cookie_injection' },
+        ],
+      });
+      const executor = createMockActionExecutor();
+      const page = createMockPage();
+      const manager = new SetupManager(config, executor as never, page as never);
+
+      const setup = manager.loadSetup('no-cookies', 'viewer');
+
+      await expect(manager.authenticate(setup)).rejects.toThrow(
+        'cookie_injection requires "cookies" path in environment "no-cookies"',
+      );
+    });
+  });
+});

--- a/packages/core/src/config/SetupManager.ts
+++ b/packages/core/src/config/SetupManager.ts
@@ -1,0 +1,107 @@
+import type { Page } from 'playwright';
+
+import type { ActionExecutor } from '../browser/ActionExecutor.js';
+
+import type { EnvironmentConfig, ProjectConfig, UserConfig } from './ProjectConfig.js';
+
+export interface ResolvedSetup {
+  environment: EnvironmentConfig;
+  user: UserConfig;
+}
+
+export class SetupManager {
+  constructor(
+    private readonly config: ProjectConfig,
+    private readonly actionExecutor: ActionExecutor,
+    private readonly page: Page,
+  ) {}
+
+  findUser(name: string): UserConfig | undefined {
+    return this.config.users.find((u) => u.name === name);
+  }
+
+  findEnvironmentForUser(userName: string): string | undefined {
+    const combination = this.config.setupCombinations.find(
+      (combo) => combo.users.includes(userName),
+    );
+    if (combination) {
+      return combination.environment;
+    }
+    return this.config.environments[0]?.name;
+  }
+
+  loadSetup(envName: string, userName: string): ResolvedSetup {
+    const environment = this.config.environments.find((e) => e.name === envName);
+    if (!environment) {
+      throw new Error(`Environment "${envName}" not found in project config`);
+    }
+
+    const user = this.findUser(userName);
+    if (!user) {
+      throw new Error(`User "${userName}" not found in project config`);
+    }
+
+    return { environment, user };
+  }
+
+  async authenticate(setup: ResolvedSetup): Promise<void> {
+    switch (setup.user.authFlow) {
+      case 'login_form':
+        await this.authenticateViaLoginForm(setup);
+        break;
+      case 'cookie_injection':
+        await this.authenticateViaCookieInjection(setup);
+        break;
+      default:
+        throw new Error(`Unknown auth flow: ${String(setup.user.authFlow)}`);
+    }
+  }
+
+  private async authenticateViaLoginForm(setup: ResolvedSetup): Promise<void> {
+    await this.actionExecutor.execute({
+      action: 'navigate',
+      target: setup.environment.baseUrl,
+      value: null,
+    });
+    await this.actionExecutor.execute({
+      action: 'fill',
+      target: 'getByLabel("Email")',
+      value: setup.user.email ?? '',
+    });
+    await this.actionExecutor.execute({
+      action: 'fill',
+      target: 'getByLabel("Password")',
+      value: setup.user.password ?? '',
+    });
+    await this.actionExecutor.execute({
+      action: 'click',
+      target: 'getByRole("button", { name: "Submit" })',
+      value: null,
+    });
+  }
+
+  private async authenticateViaCookieInjection(setup: ResolvedSetup): Promise<void> {
+    const cookiesPath = setup.environment.cookies;
+    if (!cookiesPath) {
+      throw new Error(
+        `cookie_injection requires "cookies" path in environment "${setup.environment.name}"`,
+      );
+    }
+
+    const { readFile } = await import('node:fs/promises');
+    const raw = await readFile(cookiesPath, 'utf-8');
+    const cookies = JSON.parse(raw) as Array<{
+      name: string;
+      value: string;
+      domain: string;
+      path: string;
+    }>;
+
+    await this.page.context().addCookies(cookies);
+    await this.actionExecutor.execute({
+      action: 'navigate',
+      target: setup.environment.baseUrl,
+      value: null,
+    });
+  }
+}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,1 +1,10 @@
-// Config: project configuration reader (ppia.yaml).
+export { loadProjectConfig, ProjectConfigError, resolveEnvVars } from './ProjectConfig.js';
+export type {
+  AuthFlow,
+  EnvironmentConfig,
+  ProjectConfig,
+  SetupCombination,
+  UserConfig,
+} from './ProjectConfig.js';
+export { SetupManager } from './SetupManager.js';
+export type { ResolvedSetup } from './SetupManager.js';

--- a/packages/core/src/domain/AgentContext.ts
+++ b/packages/core/src/domain/AgentContext.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentConfig, UserConfig } from '../config/ProjectConfig.js';
 import type { ExplorationReport } from './ExplorationReport.js';
 
 export interface GeneratedTest {
@@ -30,6 +31,10 @@ export interface AgentContext {
   modelStrong: string;
   maxIterations: number;
   maxGenerationAttempts: number;
+  setup?: {
+    environment: EnvironmentConfig;
+    user: UserConfig;
+  };
   explorationReport?: ExplorationReport;
   generatedTest?: GeneratedTest;
   generatedArtifacts?: GeneratedArtifacts;


### PR DESCRIPTION
## Summary

- Add `ProjectConfig` types and `loadProjectConfig()` for `ppia.yaml` parsing with env var resolution and validation
- Add `SetupManager` with `findUser()`, `loadSetup()`, `authenticate()` (login_form + cookie_injection)
- Add `SetupAgent` orchestrating pre-authentication: detects user in config, authenticates, cleans rawInput references
- Extend `AgentContext` with optional `setup` field (environment + user)
- 110 tests passing (10 test files)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)