### PR TITLE
[T13] Add setup CLI with interactive config management

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,9 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.3.0",
+    "chalk": "^5.6.2",
+    "commander": "^14.0.3",
     "yaml": "^2.8.2"
   }
 }

--- a/packages/core/src/cli/commands/setup-add.ts
+++ b/packages/core/src/cli/commands/setup-add.ts
@@ -1,0 +1,206 @@
+import { resolve } from 'node:path';
+
+import { confirm, input, password, select } from '@inquirer/prompts';
+
+import { AiServiceClient } from '../../ai/AiServiceClient.js';
+import { PythonServerManager } from '../../ai/PythonServerManager.js';
+import { ActionExecutor } from '../../browser/ActionExecutor.js';
+import { BrowserManager } from '../../browser/BrowserManager.js';
+import { HtmlExtractor } from '../../browser/HtmlExtractor.js';
+import { ConfigWriter } from '../../config/ConfigWriter.js';
+import type { AuthFlow, LoginSelectors } from '../../config/ProjectConfig.js';
+import { ExplorationAgent } from '../../agents/ExplorationAgent.js';
+import { createAgentContext } from '../../domain/AgentContext.js';
+import type { LearnedSelector } from '../../domain/ExplorationReport.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+// ── Login selector extraction ─────────────────────────────────────────
+
+function extractLoginSelectors(learnedSelectors: LearnedSelector[]): LoginSelectors | undefined {
+  let emailSelector: string | undefined;
+  let passwordSelector: string | undefined;
+  let submitSelector: string | undefined;
+
+  for (const sel of learnedSelectors) {
+    const desc = sel.description.toLowerCase();
+    const action = sel.action.toLowerCase();
+
+    if (action === 'fill' && !emailSelector && (desc.includes('email') || desc.includes('user'))) {
+      emailSelector = sel.selector;
+    } else if (action === 'fill' && !passwordSelector && desc.includes('password')) {
+      passwordSelector = sel.selector;
+    } else if (action === 'click' && !submitSelector && (desc.includes('submit') || desc.includes('login') || desc.includes('sign'))) {
+      submitSelector = sel.selector;
+    }
+  }
+
+  if (emailSelector && passwordSelector && submitSelector) {
+    return { email: emailSelector, password: passwordSelector, submit: submitSelector };
+  }
+  return undefined;
+}
+
+// ── Mini Session A: explore login form ────────────────────────────────
+
+async function exploreLoginForm(
+  baseUrl: string,
+  email: string,
+  passwordValue: string,
+): Promise<LoginSelectors | undefined> {
+  const pythonServer = new PythonServerManager();
+  const browser = new BrowserManager({ headless: false, slowMo: 150 });
+
+  try {
+    ui.info('Starting AI Service...');
+    await pythonServer.start();
+
+    ui.info('Launching browser...');
+    const page = await browser.launch();
+    const aiClient = new AiServiceClient(pythonServer.baseUrl);
+    const htmlExtractor = new HtmlExtractor();
+    const actionExecutor = new ActionExecutor(page);
+    const explorationAgent = new ExplorationAgent(aiClient, htmlExtractor, actionExecutor, page);
+
+    const objective =
+      `Navigate to ${baseUrl}, find the login form, ` +
+      `fill the email/username field with "${email}" ` +
+      `and the password field with the password, ` +
+      `then click the submit/login button.`;
+
+    const context = createAgentContext({
+      rawInput: `Login to ${baseUrl} as ${email}`,
+      url: baseUrl,
+      objective,
+      testName: 'setup-login-verification',
+      parameters: { password: passwordValue },
+      maxIterations: 10,
+    });
+
+    ui.info('Exploring login form...');
+    const report = await explorationAgent.run(context);
+
+    if (report.completed) {
+      ui.success(`Login exploration completed in ${String(report.totalRounds)} rounds`);
+      const selectors = extractLoginSelectors(report.learnedSelectors);
+      if (selectors) {
+        ui.success('Login selectors discovered');
+        ui.listItem('Email', selectors.email);
+        ui.listItem('Password', selectors.password);
+        ui.listItem('Submit', selectors.submit);
+      }
+      return selectors;
+    }
+
+    ui.warn('Login exploration did not complete — selectors not discovered');
+    return undefined;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ui.warn(`AI exploration failed: ${message}`);
+    return undefined;
+  } finally {
+    await browser.close();
+    await pythonServer.stop();
+  }
+}
+
+// ── Main action ───────────────────────────────────────────────────────
+
+export async function setupAddAction(): Promise<void> {
+  ui.header('ppia setup — Add new setup');
+
+  // 1. Collect environment data
+  const envName = await input({ message: 'Environment name:' });
+  const baseUrl = await input({ message: 'Base URL:' });
+
+  // 2. Collect user data
+  const userName = await input({ message: 'Username:' });
+  const userEmail = await input({ message: 'Email (optional):' });
+
+  const authFlow = await select<AuthFlow>({
+    message: 'Auth flow:',
+    choices: [
+      { name: 'Login form', value: 'login_form' as const },
+      { name: 'Cookie injection', value: 'cookie_injection' as const },
+    ],
+  });
+
+  const userRole = await input({ message: 'Role (optional):' });
+
+  // 3. Password handling
+  let passwordForYaml = '';
+  let resolvedPassword = '';
+
+  if (authFlow === 'login_form') {
+    const storageMode = await select({
+      message: 'How to store the password?',
+      choices: [
+        { name: 'Environment variable (recommended)', value: 'env_var' as const },
+        { name: 'Direct value', value: 'direct' as const },
+      ],
+    });
+
+    if (storageMode === 'env_var') {
+      const envVarName = await input({
+        message: 'Environment variable name:',
+        default: `${userName.toUpperCase()}_PASSWORD`,
+      });
+      passwordForYaml = `\${${envVarName}}`;
+
+      const envValue = process.env[envVarName];
+      if (envValue) {
+        resolvedPassword = envValue;
+        ui.info(`Using value from $${envVarName}`);
+      } else {
+        resolvedPassword = await password({
+          message: `Value for ${envVarName} (for verification, not stored):`,
+        });
+      }
+    } else {
+      resolvedPassword = await password({ message: 'Password:' });
+      passwordForYaml = resolvedPassword;
+    }
+  }
+
+  // 4. Optional: explore login form with AI
+  let loginSelectors: LoginSelectors | undefined;
+
+  if (authFlow === 'login_form') {
+    const shouldExplore = await confirm({
+      message: 'Explore login form with AI? (discovers selectors, requires Python AI Service)',
+      default: false,
+    });
+
+    if (shouldExplore && userEmail) {
+      loginSelectors = await exploreLoginForm(baseUrl, userEmail, resolvedPassword);
+    } else if (shouldExplore && !userEmail) {
+      ui.warn('Email is required for login exploration — skipping');
+    }
+  }
+
+  // 5. Write to ppia.yaml
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+  const writer = new ConfigWriter(configPath);
+
+  await writer.ensureProjectName(envName);
+  await writer.addEnvironment(envName, baseUrl);
+  await writer.addUser(userName, {
+    email: userEmail || undefined,
+    password: passwordForYaml || undefined,
+    role: userRole || undefined,
+    authFlow,
+    loginSelectors,
+  });
+  await writer.addSetupCombination(envName, userName);
+
+  // 6. Summary
+  ui.blank();
+  ui.success(`Setup written to ${configPath}`);
+  ui.listItem('Environment', `${envName} → ${baseUrl}`);
+  ui.listItem('User', `${userName} (${authFlow})`);
+  if (loginSelectors) {
+    ui.listItem('Selectors', 'custom (AI-discovered)');
+  } else {
+    ui.listItem('Selectors', 'default (verify with "ppia setup test")');
+  }
+  ui.blank();
+}

--- a/packages/core/src/cli/commands/setup-list.ts
+++ b/packages/core/src/cli/commands/setup-list.ts
@@ -1,0 +1,59 @@
+import { resolve } from 'node:path';
+
+import { loadProjectConfig, ProjectConfigError } from '../../config/ProjectConfig.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+export async function setupListAction(): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  try {
+    const config = await loadProjectConfig(configPath);
+
+    ui.header(`${config.projectName} — Setups`);
+
+    if (config.environments.length === 0 && config.users.length === 0) {
+      ui.warn('No setups configured. Run "ppia setup add" to create one.');
+      return;
+    }
+
+    if (config.environments.length > 0) {
+      ui.subheader('Environments');
+      for (const env of config.environments) {
+        const extra = env.cookies ? ` (cookies: ${env.cookies})` : '';
+        ui.listItem(env.name, `${env.baseUrl}${extra}`);
+      }
+    }
+
+    if (config.users.length > 0) {
+      ui.subheader('Users');
+      for (const user of config.users) {
+        const details: string[] = [user.authFlow];
+        if (user.role) {
+          details.push(user.role);
+        }
+        if (user.email) {
+          details.push(user.email);
+        }
+        if (user.loginSelectors) {
+          details.push('selectors: custom');
+        }
+        ui.listItem(user.name, details.join(' | '));
+      }
+    }
+
+    if (config.setupCombinations.length > 0) {
+      ui.subheader('Combinations');
+      for (const combo of config.setupCombinations) {
+        ui.listItem(combo.environment, combo.users.join(', '));
+      }
+    }
+
+    ui.blank();
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(err.message);
+    } else {
+      throw err;
+    }
+  }
+}

--- a/packages/core/src/cli/commands/setup-remove.ts
+++ b/packages/core/src/cli/commands/setup-remove.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path';
+
+import { ConfigWriter } from '../../config/ConfigWriter.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+export async function setupRemoveAction(envName: string, userName: string): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+  const writer = new ConfigWriter(configPath);
+
+  ui.header('ppia setup — Remove');
+
+  const removed = await writer.removeSetup(envName, userName);
+
+  if (removed) {
+    ui.success(`Setup removed: ${envName} / ${userName}`);
+  } else {
+    ui.warn(`Setup not found: ${envName} / ${userName}`);
+  }
+}

--- a/packages/core/src/cli/commands/setup-test.ts
+++ b/packages/core/src/cli/commands/setup-test.ts
@@ -1,0 +1,48 @@
+import { resolve } from 'node:path';
+
+import { ActionExecutor } from '../../browser/ActionExecutor.js';
+import { BrowserManager } from '../../browser/BrowserManager.js';
+import { loadProjectConfig, ProjectConfigError } from '../../config/ProjectConfig.js';
+import { SetupManager } from '../../config/SetupManager.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+export async function setupTestAction(envName: string, userName: string): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  ui.header('ppia setup — Test');
+  ui.info(`Testing setup: ${envName} / ${userName}`);
+
+  let config;
+  try {
+    config = await loadProjectConfig(configPath);
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(err.message);
+      return;
+    }
+    throw err;
+  }
+
+  const browser = new BrowserManager({ headless: false, slowMo: 100 });
+
+  try {
+    ui.info('Launching browser...');
+    const page = await browser.launch();
+    const actionExecutor = new ActionExecutor(page);
+    const setupManager = new SetupManager(config, actionExecutor, page);
+
+    const setup = setupManager.loadSetup(envName, userName);
+    ui.info(`Authenticating as "${userName}" on "${envName}" (${setup.environment.baseUrl})...`);
+
+    await setupManager.authenticate(setup);
+
+    ui.success('Authentication completed successfully');
+    ui.info(`Final URL: ${page.url()}`);
+    ui.blank();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ui.error(`Authentication failed: ${message}`);
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/core/src/cli/commands/setup.ts
+++ b/packages/core/src/cli/commands/setup.ts
@@ -1,0 +1,37 @@
+import { Command } from 'commander';
+
+import { setupAddAction } from './setup-add.js';
+import { setupListAction } from './setup-list.js';
+import { setupRemoveAction } from './setup-remove.js';
+import { setupTestAction } from './setup-test.js';
+
+export function createSetupCommand(): Command {
+  const setup = new Command('setup')
+    .description('Manage authentication setups in ppia.yaml');
+
+  setup
+    .command('add')
+    .description('Add a new setup interactively')
+    .action(setupAddAction);
+
+  setup
+    .command('list')
+    .description('List available setups from ppia.yaml')
+    .action(setupListAction);
+
+  setup
+    .command('test')
+    .description('Test a setup with a real browser')
+    .argument('<env>', 'Environment name')
+    .argument('<user>', 'User name')
+    .action(setupTestAction);
+
+  setup
+    .command('remove')
+    .description('Remove a setup from ppia.yaml')
+    .argument('<env>', 'Environment name')
+    .argument('<user>', 'User name')
+    .action(setupRemoveAction);
+
+  return setup;
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,3 +1,20 @@
 #!/usr/bin/env node
 
-// CLI entry point: ppia command.
+import { Command } from 'commander';
+
+import { createSetupCommand } from './commands/setup.js';
+
+const program = new Command();
+
+program
+  .name('ppia')
+  .description('AI-powered test generation for Playwright')
+  .version('0.1.0');
+
+program.addCommand(createSetupCommand());
+
+program.parseAsync().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${message}`);
+  process.exit(1);
+});

--- a/packages/core/src/cli/ui/ProgressDisplay.ts
+++ b/packages/core/src/cli/ui/ProgressDisplay.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+
+export function header(title: string): void {
+  console.log();
+  console.log(chalk.bold(`\u2726 ${title}`));
+  console.log(chalk.dim(`  ${'─'.repeat(50)}`));
+}
+
+export function subheader(title: string): void {
+  console.log();
+  console.log(chalk.bold(`  ${title}`));
+}
+
+export function info(message: string): void {
+  console.log(`  ${chalk.cyan('ℹ')} ${message}`);
+}
+
+export function success(message: string): void {
+  console.log(`  ${chalk.green('✓')} ${message}`);
+}
+
+export function error(message: string): void {
+  console.error(`  ${chalk.red('✗')} ${message}`);
+}
+
+export function warn(message: string): void {
+  console.log(`  ${chalk.yellow('!')} ${message}`);
+}
+
+export function listItem(label: string, value: string): void {
+  console.log(`    ${chalk.cyan(label)}  ${chalk.dim(value)}`);
+}
+
+export function blank(): void {
+  console.log();
+}

--- a/packages/core/src/config/ConfigWriter.ts
+++ b/packages/core/src/config/ConfigWriter.ts
@@ -1,0 +1,221 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parse, stringify } from 'yaml';
+
+import type { AuthFlow, LoginSelectors } from './ProjectConfig.js';
+
+// ── Raw YAML structure (snake_case) ───────────────────────────────────
+
+interface RawEnvironment {
+  name: string;
+  base_url: string;
+  cookies?: string;
+}
+
+interface RawLoginSelectors {
+  email: string;
+  password: string;
+  submit: string;
+}
+
+interface RawUser {
+  name: string;
+  email?: string;
+  password?: string;
+  role?: string;
+  auth_flow: string;
+  login_selectors?: RawLoginSelectors;
+}
+
+interface RawCombination {
+  environment: string;
+  users: string[];
+}
+
+interface RawYamlConfig {
+  project?: { name?: string; description?: string };
+  ai_service?: Record<string, unknown>;
+  environments?: RawEnvironment[];
+  users?: RawUser[];
+  setup_combinations?: RawCombination[];
+  output?: Record<string, unknown>;
+}
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export interface AddUserOptions {
+  email?: string;
+  password?: string;
+  role?: string;
+  authFlow: AuthFlow;
+  loginSelectors?: LoginSelectors;
+}
+
+// ── ConfigWriter ──────────────────────────────────────────────────────
+
+export class ConfigWriter {
+  constructor(private readonly filePath: string) {}
+
+  async read(): Promise<RawYamlConfig> {
+    try {
+      const content = await readFile(this.filePath, 'utf-8');
+      const parsed = parse(content) as RawYamlConfig | null;
+      return parsed ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  private async write(config: RawYamlConfig): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const content = stringify(config, { lineWidth: 120 });
+    await writeFile(this.filePath, content, 'utf-8');
+  }
+
+  async ensureProjectName(name: string): Promise<void> {
+    const config = await this.read();
+    if (!config.project) {
+      config.project = {};
+    }
+    if (!config.project.name) {
+      config.project.name = name;
+    }
+    await this.write(config);
+  }
+
+  async addEnvironment(name: string, baseUrl: string, cookies?: string): Promise<void> {
+    const config = await this.read();
+    if (!config.environments) {
+      config.environments = [];
+    }
+
+    const existing = config.environments.find((e) => e.name === name);
+    if (existing) {
+      existing.base_url = baseUrl;
+      if (cookies) {
+        existing.cookies = cookies;
+      }
+    } else {
+      const entry: RawEnvironment = { name, base_url: baseUrl };
+      if (cookies) {
+        entry.cookies = cookies;
+      }
+      config.environments.push(entry);
+    }
+
+    await this.write(config);
+  }
+
+  async addUser(name: string, options: AddUserOptions): Promise<void> {
+    const config = await this.read();
+    if (!config.users) {
+      config.users = [];
+    }
+
+    const entry: RawUser = {
+      name,
+      auth_flow: options.authFlow,
+    };
+    if (options.email) {
+      entry.email = options.email;
+    }
+    if (options.password) {
+      entry.password = options.password;
+    }
+    if (options.role) {
+      entry.role = options.role;
+    }
+    if (options.loginSelectors) {
+      entry.login_selectors = {
+        email: options.loginSelectors.email,
+        password: options.loginSelectors.password,
+        submit: options.loginSelectors.submit,
+      };
+    }
+
+    const existingIndex = config.users.findIndex((u) => u.name === name);
+    if (existingIndex !== -1) {
+      config.users[existingIndex] = entry;
+    } else {
+      config.users.push(entry);
+    }
+
+    await this.write(config);
+  }
+
+  async addSetupCombination(envName: string, userName: string): Promise<void> {
+    const config = await this.read();
+    if (!config.setup_combinations) {
+      config.setup_combinations = [];
+    }
+
+    const existing = config.setup_combinations.find((c) => c.environment === envName);
+    if (existing) {
+      if (!existing.users.includes(userName)) {
+        existing.users.push(userName);
+      }
+    } else {
+      config.setup_combinations.push({
+        environment: envName,
+        users: [userName],
+      });
+    }
+
+    await this.write(config);
+  }
+
+  async removeSetup(envName: string, userName: string): Promise<boolean> {
+    const config = await this.read();
+    if (!config.setup_combinations) {
+      return false;
+    }
+
+    const combo = config.setup_combinations.find((c) => c.environment === envName);
+    if (!combo) {
+      return false;
+    }
+
+    const userIndex = combo.users.indexOf(userName);
+    if (userIndex === -1) {
+      return false;
+    }
+
+    combo.users.splice(userIndex, 1);
+
+    if (combo.users.length === 0) {
+      config.setup_combinations = config.setup_combinations.filter(
+        (c) => c.environment !== envName,
+      );
+    }
+
+    // Also remove the user definition if not used in any other combination
+    const userStillUsed = config.setup_combinations.some(
+      (c) => c.users.includes(userName),
+    );
+    if (!userStillUsed && config.users) {
+      config.users = config.users.filter((u) => u.name !== userName);
+    }
+
+    // Also remove the environment if no combinations reference it
+    const envStillUsed = config.setup_combinations.some(
+      (c) => c.environment === envName,
+    );
+    if (!envStillUsed && config.environments) {
+      config.environments = config.environments.filter((e) => e.name !== envName);
+    }
+
+    await this.write(config);
+    return true;
+  }
+
+  async hasEnvironment(name: string): Promise<boolean> {
+    const config = await this.read();
+    return config.environments?.some((e) => e.name === name) ?? false;
+  }
+
+  async hasUser(name: string): Promise<boolean> {
+    const config = await this.read();
+    return config.users?.some((u) => u.name === name) ?? false;
+  }
+}

--- a/packages/core/src/config/ProjectConfig.ts
+++ b/packages/core/src/config/ProjectConfig.ts
@@ -12,12 +12,19 @@ export interface EnvironmentConfig {
 
 export type AuthFlow = 'login_form' | 'cookie_injection';
 
+export interface LoginSelectors {
+  email: string;
+  password: string;
+  submit: string;
+}
+
 export interface UserConfig {
   name: string;
   email?: string;
   password?: string;
   role?: string;
   authFlow: AuthFlow;
+  loginSelectors?: LoginSelectors;
 }
 
 export interface SetupCombination {
@@ -56,6 +63,7 @@ interface RawUser {
   password?: unknown;
   role?: unknown;
   auth_flow?: unknown;
+  login_selectors?: unknown;
 }
 
 interface RawCombination {
@@ -110,6 +118,17 @@ function parseEnvironment(raw: RawEnvironment, index: number): EnvironmentConfig
   };
 }
 
+function parseLoginSelectors(raw: unknown): LoginSelectors | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.email !== 'string' || typeof obj.password !== 'string' || typeof obj.submit !== 'string') {
+    return undefined;
+  }
+  return { email: obj.email, password: obj.password, submit: obj.submit };
+}
+
 function parseUser(raw: RawUser, index: number): UserConfig {
   if (typeof raw.name !== 'string' || raw.name.length === 0) {
     throw new ProjectConfigError(
@@ -123,13 +142,18 @@ function parseUser(raw: RawUser, index: number): UserConfig {
       `users[${String(index)}].auth_flow`,
     );
   }
-  return {
+  const user: UserConfig = {
     name: raw.name,
     email: resolveOptionalString(raw.email),
     password: resolveOptionalString(raw.password),
     role: typeof raw.role === 'string' ? raw.role : undefined,
     authFlow: raw.auth_flow as AuthFlow,
   };
+  const loginSelectors = parseLoginSelectors(raw.login_selectors);
+  if (loginSelectors) {
+    user.loginSelectors = loginSelectors;
+  }
+  return user;
 }
 
 function parseCombination(

--- a/packages/core/src/config/SetupManager.ts
+++ b/packages/core/src/config/SetupManager.ts
@@ -58,6 +58,12 @@ export class SetupManager {
   }
 
   private async authenticateViaLoginForm(setup: ResolvedSetup): Promise<void> {
+    const selectors = setup.user.loginSelectors ?? {
+      email: 'getByLabel("Email")',
+      password: 'getByLabel("Password")',
+      submit: 'getByRole("button", { name: "Submit" })',
+    };
+
     await this.actionExecutor.execute({
       action: 'navigate',
       target: setup.environment.baseUrl,
@@ -65,17 +71,17 @@ export class SetupManager {
     });
     await this.actionExecutor.execute({
       action: 'fill',
-      target: 'getByLabel("Email")',
+      target: selectors.email,
       value: setup.user.email ?? '',
     });
     await this.actionExecutor.execute({
       action: 'fill',
-      target: 'getByLabel("Password")',
+      target: selectors.password,
       value: setup.user.password ?? '',
     });
     await this.actionExecutor.execute({
       action: 'click',
-      target: 'getByRole("button", { name: "Submit" })',
+      target: selectors.submit,
       value: null,
     });
   }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -2,9 +2,12 @@ export { loadProjectConfig, ProjectConfigError, resolveEnvVars } from './Project
 export type {
   AuthFlow,
   EnvironmentConfig,
+  LoginSelectors,
   ProjectConfig,
   SetupCombination,
   UserConfig,
 } from './ProjectConfig.js';
+export { ConfigWriter } from './ConfigWriter.js';
+export type { AddUserOptions } from './ConfigWriter.js';
 export { SetupManager } from './SetupManager.js';
 export type { ResolvedSetup } from './SetupManager.js';


### PR DESCRIPTION
## Summary

- Implement `ppia setup add/list/test/remove` CLI subcommands using commander + @inquirer/prompts + chalk
- Add `ConfigWriter` for reading, modifying and writing `ppia.yaml` (environments, users, combinations)
- Extend `ProjectConfig` with `LoginSelectors` type for storing AI-discovered login form selectors
- Update `SetupManager` to use custom login selectors when available (fallback to defaults)
- Optional mini session A in `setup add`: AI-driven login form exploration via `ExplorationAgent`

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint src` passes
- [x] `vitest run` — 110 tests passing (0 broken)
- [ ] Manual: `ppia setup add` interactive flow
- [ ] Manual: `ppia setup list` displays config
- [ ] Manual: `ppia setup test <env> <user>` authenticates via browser
- [ ] Manual: `ppia setup remove <env> <user>` cleans up config

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)