### PR TITLE
[T14] Add ppia generate CLI with real-time progress

### DIFF
--- a/packages/core/src/agents/ExplorationAgent.ts
+++ b/packages/core/src/agents/ExplorationAgent.ts
@@ -9,6 +9,8 @@ import type {
 } from '../domain/ExplorationReport.js';
 import type { Page } from 'playwright';
 
+export type ExplorationProgressCallback = (round: ExplorationRound) => void;
+
 export class ExplorationAgent {
   constructor(
     private readonly aiClient: AiServiceClient,
@@ -17,7 +19,10 @@ export class ExplorationAgent {
     private readonly page: Page,
   ) {}
 
-  async run(context: AgentContext): Promise<ExplorationReport> {
+  async run(
+    context: AgentContext,
+    onProgress?: ExplorationProgressCallback,
+  ): Promise<ExplorationReport> {
     const { sessionId } = await this.aiClient.createSession();
     const rounds: ExplorationRound[] = [];
     let completed = false;
@@ -58,6 +63,7 @@ export class ExplorationAgent {
         if (response.completed) {
           completed = true;
           rounds.push(round);
+          onProgress?.(round);
           break;
         }
 
@@ -76,6 +82,7 @@ export class ExplorationAgent {
         }
 
         rounds.push(round);
+        onProgress?.(round);
       }
 
       if (!completed) {

--- a/packages/core/src/agents/GenerationAgent.ts
+++ b/packages/core/src/agents/GenerationAgent.ts
@@ -4,13 +4,24 @@ import type { AgentContext } from '../domain/AgentContext.js';
 import type { GenerationResult } from '../domain/GenerationResult.js';
 import type { TestExecutor } from '../executor/TestExecutor.js';
 
+export interface GenerationProgressEvent {
+  phase: 'test_generated' | 'test_passed' | 'test_failed' | 'artifacts_generated';
+  attempt: number;
+  tokensUsed: number;
+}
+
+export type GenerationProgressCallback = (event: GenerationProgressEvent) => void;
+
 export class GenerationAgent {
   constructor(
     private readonly aiClient: AiServiceClient,
     private readonly testExecutor: TestExecutor,
   ) {}
 
-  async run(context: AgentContext): Promise<GenerationResult> {
+  async run(
+    context: AgentContext,
+    onProgress?: GenerationProgressCallback,
+  ): Promise<GenerationResult> {
     if (!context.explorationReport) {
       throw new Error('GenerationAgent requires an explorationReport in context');
     }
@@ -37,14 +48,18 @@ export class GenerationAgent {
 
         const testResponse = await this.aiClient.generateTest(sessionId, request);
         totalTokensUsed += testResponse.tokensUsed;
+        onProgress?.({ phase: 'test_generated', attempt, tokensUsed: testResponse.tokensUsed });
 
         const result = await this.testExecutor.execute(testResponse.code, context.testName);
 
         if (result.passed) {
+          onProgress?.({ phase: 'test_passed', attempt, tokensUsed: 0 });
+
           const artifactsResponse = await this.aiClient.generateArtifacts(sessionId, {
             model: context.modelStrong,
           });
           totalTokensUsed += artifactsResponse.tokensUsed;
+          onProgress?.({ phase: 'artifacts_generated', attempt, tokensUsed: artifactsResponse.tokensUsed });
 
           return {
             generatedTest: {
@@ -63,6 +78,7 @@ export class GenerationAgent {
           };
         }
 
+        onProgress?.({ phase: 'test_failed', attempt, tokensUsed: 0 });
         lastFailedCode = testResponse.code;
         lastError = result.errorMessage ?? 'Test failed with unknown error';
       } finally {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,4 +1,6 @@
 export { ExplorationAgent } from './ExplorationAgent.js';
+export type { ExplorationProgressCallback } from './ExplorationAgent.js';
 export { GenerationAgent } from './GenerationAgent.js';
+export type { GenerationProgressCallback, GenerationProgressEvent } from './GenerationAgent.js';
 export { SetupAgent } from './SetupAgent.js';
 export type { SetupResult } from './SetupAgent.js';

--- a/packages/core/src/ai/AiServiceTypes.ts
+++ b/packages/core/src/ai/AiServiceTypes.ts
@@ -17,6 +17,7 @@ export interface PrepareInputResponse {
   objective: string;
   testName: string;
   parameters: Record<string, string>;
+  detectedUser?: string;
   tokensUsed: number;
 }
 

--- a/packages/core/src/cli/commands/generate.ts
+++ b/packages/core/src/cli/commands/generate.ts
@@ -1,0 +1,207 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+
+import type { Command } from 'commander';
+
+import { AiServiceClient } from '../../ai/AiServiceClient.js';
+import { PythonServerManager } from '../../ai/PythonServerManager.js';
+import { ExplorationAgent } from '../../agents/ExplorationAgent.js';
+import { GenerationAgent } from '../../agents/GenerationAgent.js';
+import { SetupAgent } from '../../agents/SetupAgent.js';
+import { ActionExecutor } from '../../browser/ActionExecutor.js';
+import { BrowserManager } from '../../browser/BrowserManager.js';
+import { HtmlExtractor } from '../../browser/HtmlExtractor.js';
+import { loadProjectConfig } from '../../config/ProjectConfig.js';
+import { SetupManager } from '../../config/SetupManager.js';
+import { createAgentContext } from '../../domain/AgentContext.js';
+import { TestExecutor } from '../../executor/TestExecutor.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+interface GenerateOptions {
+  setup?: string;
+  user?: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+async function writeArtifacts(
+  testFilePath: string,
+  testName: string,
+  artifacts: { pomMd: string; gherkinMd: string; cucumberMd: string },
+): Promise<void> {
+  const dir = dirname(testFilePath);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, `${testName}.pom.md`), artifacts.pomMd, 'utf-8');
+  await writeFile(join(dir, `${testName}.gherkin.md`), artifacts.gherkinMd, 'utf-8');
+  await writeFile(join(dir, `${testName}.cucumber.md`), artifacts.cucumberMd, 'utf-8');
+}
+
+async function writeMetrics(
+  outputDir: string,
+  testName: string,
+  metrics: Record<string, unknown>,
+): Promise<void> {
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    join(outputDir, `${testName}.metrics.json`),
+    JSON.stringify(metrics, null, 2),
+    'utf-8',
+  );
+}
+
+// ── Main action ───────────────────────────────────────────────────────
+
+async function generateAction(description: string, options: GenerateOptions): Promise<void> {
+  const outputDir = resolve(process.cwd(), 'output');
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  const pythonServer = new PythonServerManager();
+  const browser = new BrowserManager({ headless: false });
+  const modelFast = 'gpt-4o-mini';
+  const modelStrong = 'gpt-4o';
+  let totalTokens = 0;
+  let totalCost = 0;
+
+  try {
+    // ── 1. Start AI Service ───────────────────────────────────────────
+    ui.header('ppia generate');
+    ui.info('Starting AI Service...');
+    await pythonServer.start();
+    const aiClient = new AiServiceClient(pythonServer.baseUrl);
+    ui.success('AI Service ready');
+
+    // ── 2. Session 0: parse input ─────────────────────────────────────
+    const prepared = await aiClient.prepareInput({ rawInput: description });
+    totalTokens += prepared.tokensUsed;
+    totalCost += ui.estimateCost(modelFast, prepared.tokensUsed);
+    ui.phaseRow('Session 0', 'input analysis', modelFast, prepared.tokensUsed);
+
+    // ── 3. Build context ──────────────────────────────────────────────
+    let context = createAgentContext({
+      rawInput: description,
+      url: prepared.url,
+      objective: prepared.objective,
+      testName: prepared.testName,
+      parameters: prepared.parameters,
+      modelFast,
+      modelStrong,
+    });
+
+    // ── 4. Launch browser ─────────────────────────────────────────────
+    ui.info('Launching browser...');
+    const page = await browser.launch();
+    const actionExecutor = new ActionExecutor(page);
+    const htmlExtractor = new HtmlExtractor();
+
+    // ── 5. Setup (optional) ───────────────────────────────────────────
+    const detectedUser = prepared.detectedUser ?? options.user;
+    if (detectedUser) {
+      try {
+        const config = await loadProjectConfig(configPath);
+        const setupManager = new SetupManager(config, actionExecutor, page);
+        const setupAgent = new SetupAgent(setupManager);
+        const setupResult = await setupAgent.run(context, detectedUser, options.setup);
+        if (setupResult.authenticated) {
+          context = setupResult.context;
+          ui.success(`Authenticated as "${detectedUser}"`);
+        } else {
+          ui.warn(`User "${detectedUser}" not found in config, continuing without setup`);
+        }
+      } catch {
+        ui.warn('Setup config not available, continuing without authentication');
+      }
+    }
+
+    // ── 6. Exploration (Session A) ────────────────────────────────────
+    ui.blank();
+    const explorationAgent = new ExplorationAgent(aiClient, htmlExtractor, actionExecutor, page);
+
+    const explorationReport = await explorationAgent.run(context, (round) => {
+      totalTokens += round.tokensUsed;
+      totalCost += ui.estimateCost(modelFast, round.tokensUsed);
+      const detail = round.actionError
+        ? `round ${String(round.round)} (err)`
+        : `round ${String(round.round)}`;
+      ui.phaseRow('Exploration', detail, modelFast, round.tokensUsed);
+    });
+
+    ui.success(`Exploration completed in ${String(explorationReport.totalRounds)} rounds`);
+
+    // ── 7. Generation (Session B) ─────────────────────────────────────
+    ui.blank();
+    const genContext = { ...context, explorationReport };
+    const testExecutor = new TestExecutor(outputDir);
+    const generationAgent = new GenerationAgent(aiClient, testExecutor);
+
+    const genResult = await generationAgent.run(genContext, (event) => {
+      totalTokens += event.tokensUsed;
+      totalCost += ui.estimateCost(modelStrong, event.tokensUsed);
+
+      switch (event.phase) {
+        case 'test_generated':
+          ui.phaseRow('Generation', `attempt ${String(event.attempt)}`, modelStrong, event.tokensUsed);
+          break;
+        case 'test_failed':
+          ui.warn(`Test attempt ${String(event.attempt)} failed, retrying...`);
+          break;
+        case 'test_passed':
+          ui.success(`Test passed on attempt ${String(event.attempt)}`);
+          break;
+        case 'artifacts_generated':
+          ui.phaseRow('Artifacts', 'POM+Gherkin', modelStrong, event.tokensUsed);
+          break;
+      }
+    });
+
+    // ── 8. Write artifacts ────────────────────────────────────────────
+    const testPath = genResult.generatedTest.filePath ?? join(outputDir, `${prepared.testName}.spec.ts`);
+    await writeArtifacts(testPath, prepared.testName, genResult.generatedArtifacts);
+
+    // ── 9. Write metrics ──────────────────────────────────────────────
+    await writeMetrics(outputDir, prepared.testName, {
+      totalTokens,
+      totalCost,
+      modelFast,
+      modelStrong,
+      explorationRounds: explorationReport.totalRounds,
+      generationAttempts: genResult.attempts,
+      timestamp: new Date().toISOString(),
+    });
+
+    // ── 10. Summary ───────────────────────────────────────────────────
+    ui.separator();
+    ui.generateSummary({
+      totalTokens,
+      totalCost,
+      explorationRounds: explorationReport.totalRounds,
+      generationAttempts: genResult.attempts,
+      testPath,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ui.error(message);
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+    await pythonServer.stop();
+  }
+}
+
+// ── Command registration ──────────────────────────────────────────────
+
+export function registerGenerateCommand(program: Command): void {
+  program
+    .command('generate')
+    .description('Generate an E2E test from a natural language description')
+    .argument('<description>', 'Test description in natural language')
+    .option('-s, --setup <env>', 'Environment name for authentication setup')
+    .option('-u, --user <user>', 'User name for authentication')
+    .action(async (description: string, opts: Record<string, unknown>) => {
+      await generateAction(description, {
+        setup: typeof opts.setup === 'string' ? opts.setup : undefined,
+        user: typeof opts.user === 'string' ? opts.user : undefined,
+      });
+    });
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 
+import { registerGenerateCommand } from './commands/generate.js';
 import { createSetupCommand } from './commands/setup.js';
 
 const program = new Command();
@@ -11,6 +12,7 @@ program
   .description('AI-powered test generation for Playwright')
   .version('0.1.0');
 
+registerGenerateCommand(program);
 program.addCommand(createSetupCommand());
 
 program.parseAsync().catch((err: unknown) => {

--- a/packages/core/src/cli/ui/ProgressDisplay.ts
+++ b/packages/core/src/cli/ui/ProgressDisplay.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
 
+// ── Basic UI ──────────────────────────────────────────────────────────
+
 export function header(title: string): void {
   console.log();
   console.log(chalk.bold(`\u2726 ${title}`));
@@ -33,4 +35,76 @@ export function listItem(label: string, value: string): void {
 
 export function blank(): void {
   console.log();
+}
+
+// ── Cost estimation ───────────────────────────────────────────────────
+
+// Blended rate per token (approximate input/output average) in USD.
+const MODEL_RATES: Record<string, number> = {
+  'gpt-4o-mini': 0.3e-6,
+  'gpt-4o': 5.0e-6,
+  'claude-haiku-4-5': 2.0e-6,
+  'claude-sonnet-4-5': 6.0e-6,
+  'claude-sonnet-4-6': 6.0e-6,
+  'claude-opus-4-6': 30.0e-6,
+};
+
+const DEFAULT_RATE = 3.0e-6;
+
+export function estimateCost(model: string, tokens: number): number {
+  const rate = MODEL_RATES[model] ?? DEFAULT_RATE;
+  return tokens * rate;
+}
+
+export function formatCost(cost: number): string {
+  if (cost < 0.01) {
+    return `~$${cost.toFixed(5)}`;
+  }
+  return `~$${cost.toFixed(3)}`;
+}
+
+export function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k tok`;
+  }
+  return `${String(tokens)} tok`;
+}
+
+// ── Generate progress ─────────────────────────────────────────────────
+
+export function phaseRow(phase: string, detail: string, model: string, tokens: number): void {
+  const cost = estimateCost(model, tokens);
+  console.log(
+    `  ${chalk.cyan('◉')} ` +
+    `${phase.padEnd(15)} ` +
+    `${detail.padEnd(16)} ` +
+    `${chalk.dim(model.padEnd(18))} ` +
+    `${formatTokens(tokens).padStart(10)}   ` +
+    chalk.dim(formatCost(cost)),
+  );
+}
+
+export function separator(): void {
+  console.log(chalk.dim(`  ${'─'.repeat(50)}`));
+}
+
+export interface GenerateSummary {
+  totalTokens: number;
+  totalCost: number;
+  explorationRounds: number;
+  generationAttempts: number;
+  testPath: string;
+}
+
+export function generateSummary(summary: GenerateSummary): void {
+  blank();
+  success(
+    `Test generated  |  ${formatTokens(summary.totalTokens)}  |  ${formatCost(summary.totalCost)}`,
+  );
+  listItem('Exploration', `${String(summary.explorationRounds)} rounds`);
+  listItem('Generation', `${String(summary.generationAttempts)} attempt${summary.generationAttempts > 1 ? 's' : ''}`);
+  if (summary.testPath) {
+    listItem('Output', summary.testPath);
+  }
+  blank();
 }


### PR DESCRIPTION
## Summary
- Implement ppia generate command orchestrating the full end-to-end flow
- Add optional progress callbacks to ExplorationAgent and GenerationAgent
- Real-time terminal display with per-call token count and cost estimation
- Add detectedUser field to PrepareInputResponse for SetupAgent integration
- Write artifacts and metrics JSON alongside generated test

Closes #15