### PR TITLE
feat(suite): add SuiteManager and KnowledgeBase

### DIFF
--- a/packages/core/src/suite/KnowledgeBase.test.ts
+++ b/packages/core/src/suite/KnowledgeBase.test.ts
@@ -1,0 +1,198 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+import type { KnowledgeEntry } from './KnowledgeEntry.js';
+import { KnowledgeBase } from './KnowledgeBase.js';
+
+const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
+const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
+
+function getWrittenData(): KnowledgeEntry[] {
+  const call = mockWriteFile.mock.calls[0] as string[];
+  return JSON.parse(call[1] as string) as KnowledgeEntry[];
+}
+
+function createKnowledgeEntry(overrides: Partial<KnowledgeEntry> = {}): KnowledgeEntry {
+  return {
+    url: 'https://example.com/login',
+    elementDescription: 'email input',
+    reliableSelector: 'getByLabel("Email")',
+    problematicSelectors: ['#email-input'],
+    learnedFrom: 'login-test',
+    learnedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('KnowledgeBase', () => {
+  const baseDir = '/project';
+  let kb: KnowledgeBase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    kb = new KnowledgeBase(baseDir);
+  });
+
+  describe('getByUrl', () => {
+    it('returns entries matching the given URL', async () => {
+      const entry1 = createKnowledgeEntry();
+      const entry2 = createKnowledgeEntry({
+        url: 'https://example.com/login',
+        elementDescription: 'password input',
+        reliableSelector: 'getByLabel("Password")',
+      });
+      const entry3 = createKnowledgeEntry({ url: 'https://example.com/dashboard' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([entry1, entry2, entry3]));
+
+      const result = await kb.getByUrl('https://example.com/login');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.elementDescription).toBe('email input');
+      expect(result[1]?.elementDescription).toBe('password input');
+    });
+
+    it('returns empty array when no entries exist', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await kb.getByUrl('https://example.com/login');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('adds new entries without removing existing ones', async () => {
+      const existing = createKnowledgeEntry();
+      const newEntry = createKnowledgeEntry({
+        url: 'https://example.com/dashboard',
+        elementDescription: 'nav menu',
+        reliableSelector: 'getByRole("navigation")',
+      });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([existing]));
+
+      await kb.update('https://example.com/dashboard', [newEntry]);
+
+      const written = getWrittenData();
+      expect(written).toHaveLength(2);
+      expect(written[0]).toEqual(existing);
+      expect(written[1]).toEqual(newEntry);
+    });
+
+    it('updates existing entries with matching url + elementDescription', async () => {
+      const existing = createKnowledgeEntry({ reliableSelector: 'old-selector' });
+      const updated = createKnowledgeEntry({ reliableSelector: 'new-selector' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([existing]));
+
+      await kb.update('https://example.com/login', [updated]);
+
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.reliableSelector).toBe('new-selector');
+    });
+
+    it('creates the file when it does not exist', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+      const entry = createKnowledgeEntry();
+
+      await kb.update('https://example.com/login', [entry]);
+
+      expect(mockMkdir).toHaveBeenCalled();
+      expect(mockWriteFile).toHaveBeenCalled();
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all entries when called without options', async () => {
+      const entries = [createKnowledgeEntry(), createKnowledgeEntry({ url: 'https://other.com' })];
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(entries));
+
+      const count = await kb.reset();
+
+      expect(count).toBe(2);
+      const written = getWrittenData();
+      expect(written).toEqual([]);
+    });
+
+    it('removes entries for an exact URL', async () => {
+      const keep = createKnowledgeEntry({ url: 'https://other.com' });
+      const remove = createKnowledgeEntry({ url: 'https://example.com/login' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep, remove]));
+
+      const count = await kb.reset({ url: 'https://example.com/login' });
+
+      expect(count).toBe(1);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://other.com');
+    });
+
+    it('removes entries matching an exact path', async () => {
+      const keep = createKnowledgeEntry({ url: 'https://example.com/dashboard' });
+      const remove = createKnowledgeEntry({ url: 'https://example.com/admin' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep, remove]));
+
+      const count = await kb.reset({ path: '/admin' });
+
+      expect(count).toBe(1);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://example.com/dashboard');
+    });
+
+    it('removes entries matching path and sub-paths with deep option', async () => {
+      const keep = createKnowledgeEntry({ url: 'https://example.com/dashboard' });
+      const remove1 = createKnowledgeEntry({ url: 'https://example.com/admin' });
+      const remove2 = createKnowledgeEntry({ url: 'https://example.com/admin/users' });
+      const remove3 = createKnowledgeEntry({ url: 'https://example.com/admin/settings' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep, remove1, remove2, remove3]));
+
+      const count = await kb.reset({ path: '/admin', deep: true });
+
+      expect(count).toBe(3);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://example.com/dashboard');
+    });
+
+    it('does not remove sub-paths when deep is false', async () => {
+      const keep1 = createKnowledgeEntry({ url: 'https://example.com/admin/users' });
+      const remove = createKnowledgeEntry({ url: 'https://example.com/admin' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep1, remove]));
+
+      const count = await kb.reset({ path: '/admin' });
+
+      expect(count).toBe(1);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://example.com/admin/users');
+    });
+
+    it('returns 0 when there are no entries to clear', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const count = await kb.reset();
+
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns all entries', async () => {
+      const entries = [createKnowledgeEntry(), createKnowledgeEntry({ url: 'https://other.com' })];
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(entries));
+
+      const result = await kb.getAll();
+
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/packages/core/src/suite/KnowledgeBase.ts
+++ b/packages/core/src/suite/KnowledgeBase.ts
@@ -1,0 +1,102 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { join } from 'node:path';
+
+import type { KnowledgeEntry, ResetOptions } from './KnowledgeEntry.js';
+
+export class KnowledgeBase {
+  private readonly filePath: string;
+
+  constructor(baseDir: string) {
+    this.filePath = join(baseDir, '.ppia', 'knowledge.json');
+  }
+
+  async getByUrl(url: string): Promise<KnowledgeEntry[]> {
+    const all = await this.readAll();
+    return all.filter((e) => e.url === url);
+  }
+
+  async update(url: string, entries: KnowledgeEntry[]): Promise<void> {
+    const all = await this.readAll();
+
+    for (const incoming of entries) {
+      const idx = all.findIndex(
+        (e) => e.url === incoming.url && e.elementDescription === incoming.elementDescription,
+      );
+      if (idx >= 0) {
+        all[idx] = incoming;
+      } else {
+        all.push(incoming);
+      }
+    }
+
+    await this.writeAll(all);
+  }
+
+  async reset(options?: ResetOptions): Promise<number> {
+    if (!options?.url && !options?.path) {
+      const all = await this.readAll();
+      const count = all.length;
+      await this.writeAll([]);
+      return count;
+    }
+
+    const all = await this.readAll();
+    const before = all.length;
+
+    let filtered: KnowledgeEntry[];
+
+    if (options.url) {
+      filtered = all.filter((e) => e.url !== options.url);
+    } else if (options.path) {
+      const targetPath = options.path;
+      filtered = all.filter((e) => !matchesPath(e.url, targetPath, options.deep ?? false));
+    } else {
+      filtered = all;
+    }
+
+    await this.writeAll(filtered);
+    return before - filtered.length;
+  }
+
+  async getAll(): Promise<KnowledgeEntry[]> {
+    return this.readAll();
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────
+
+  private async readAll(): Promise<KnowledgeEntry[]> {
+    try {
+      const raw = await readFile(this.filePath, 'utf-8');
+      return JSON.parse(raw) as KnowledgeEntry[];
+    } catch {
+      return [];
+    }
+  }
+
+  private async writeAll(entries: KnowledgeEntry[]): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, JSON.stringify(entries, null, 2), 'utf-8');
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function matchesPath(entryUrl: string, path: string, deep: boolean): boolean {
+  let urlPath: string;
+  try {
+    urlPath = new URL(entryUrl).pathname;
+  } catch {
+    return false;
+  }
+
+  // Normalize: remove trailing slash for comparison (unless root "/")
+  const normalizedUrlPath = urlPath.length > 1 ? urlPath.replace(/\/$/, '') : urlPath;
+  const normalizedTarget = path.length > 1 ? path.replace(/\/$/, '') : path;
+
+  if (deep) {
+    return normalizedUrlPath === normalizedTarget || normalizedUrlPath.startsWith(`${normalizedTarget}/`);
+  }
+
+  return normalizedUrlPath === normalizedTarget;
+}

--- a/packages/core/src/suite/KnowledgeEntry.ts
+++ b/packages/core/src/suite/KnowledgeEntry.ts
@@ -1,0 +1,14 @@
+export interface KnowledgeEntry {
+  url: string;
+  elementDescription: string;
+  reliableSelector: string;
+  problematicSelectors: string[];
+  learnedFrom: string;
+  learnedAt: string;
+}
+
+export interface ResetOptions {
+  url?: string;
+  path?: string;
+  deep?: boolean;
+}

--- a/packages/core/src/suite/SuiteEntry.ts
+++ b/packages/core/src/suite/SuiteEntry.ts
@@ -1,0 +1,28 @@
+export interface SuiteEntryMetrics {
+  totalTokensUsed: number;
+  totalCost: number;
+  modelFast: string;
+  modelStrong: string;
+  explorationRounds: number;
+  generationAttempts: number;
+  timestamp: string;
+}
+
+export interface SuiteEntryArtifacts {
+  pomMd: string;
+  gherkinMd: string;
+  cucumberMd: string;
+}
+
+export interface SuiteEntry {
+  id: string;
+  testName: string;
+  description: string;
+  url: string;
+  testCode: string;
+  testFilePath?: string;
+  artifacts: SuiteEntryArtifacts;
+  metrics: SuiteEntryMetrics;
+  version: number;
+  createdAt: string;
+}

--- a/packages/core/src/suite/SuiteManager.test.ts
+++ b/packages/core/src/suite/SuiteManager.test.ts
@@ -1,0 +1,166 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+import type { SuiteEntry } from './SuiteEntry.js';
+import { SuiteManager } from './SuiteManager.js';
+
+const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
+const mockReaddir = readdir as unknown as ReturnType<typeof vi.fn>;
+const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
+
+function createEntry(overrides: Partial<SuiteEntry> = {}): SuiteEntry {
+  return {
+    id: 'test-id-1',
+    testName: 'login-test',
+    description: 'Test login flow',
+    url: 'https://example.com/login',
+    testCode: 'test("login", async () => {});',
+    artifacts: { pomMd: '# POM', gherkinMd: '# Gherkin', cucumberMd: '# Cucumber' },
+    metrics: {
+      totalTokensUsed: 1000,
+      totalCost: 0.005,
+      modelFast: 'gpt-4o-mini',
+      modelStrong: 'gpt-4o',
+      explorationRounds: 5,
+      generationAttempts: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+    },
+    version: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('SuiteManager', () => {
+  const baseDir = '/project';
+  let manager: SuiteManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new SuiteManager(baseDir);
+  });
+
+  describe('save', () => {
+    it('creates directory and writes latest + history for a new entry', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+      const entry = createEntry();
+
+      await manager.save(entry);
+
+      const testDir = join(baseDir, '.ppia', 'suite', 'login-test');
+      expect(mockMkdir).toHaveBeenCalledWith(testDir, { recursive: true });
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        join(testDir, 'latest.json'),
+        JSON.stringify(entry, null, 2),
+        'utf-8',
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        join(testDir, 'history.json'),
+        JSON.stringify([entry], null, 2),
+        'utf-8',
+      );
+    });
+
+    it('appends to existing history', async () => {
+      const v1 = createEntry({ id: 'v1', version: 1 });
+      const v2 = createEntry({ id: 'v2', version: 2 });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([v1]));
+
+      await manager.save(v2);
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('history.json'),
+        JSON.stringify([v1, v2], null, 2),
+        'utf-8',
+      );
+    });
+  });
+
+  describe('list', () => {
+    it('returns empty array when suite directory does not exist', async () => {
+      mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await manager.list();
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns latest entries for all tests', async () => {
+      const entry1 = createEntry({ testName: 'test-a' });
+      const entry2 = createEntry({ testName: 'test-b' });
+      mockReaddir.mockResolvedValueOnce(['test-a', 'test-b']);
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(entry1))
+        .mockResolvedValueOnce(JSON.stringify(entry2));
+
+      const result = await manager.list();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.testName).toBe('test-a');
+      expect(result[1]?.testName).toBe('test-b');
+    });
+
+    it('skips entries that fail to read', async () => {
+      const entry1 = createEntry({ testName: 'test-a' });
+      mockReaddir.mockResolvedValueOnce(['test-a', 'broken']);
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(entry1))
+        .mockRejectedValueOnce(new Error('corrupt'));
+
+      const result = await manager.list();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.testName).toBe('test-a');
+    });
+  });
+
+  describe('getById', () => {
+    it('returns the latest entry for a test name', async () => {
+      const entry = createEntry();
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(entry));
+
+      const result = await manager.getById('login-test');
+
+      expect(result).toEqual(entry);
+    });
+
+    it('returns undefined when test does not exist', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await manager.getById('nonexistent');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getVersions', () => {
+    it('returns full history for a test', async () => {
+      const v1 = createEntry({ id: 'v1', version: 1 });
+      const v2 = createEntry({ id: 'v2', version: 2 });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([v1, v2]));
+
+      const result = await manager.getVersions('login-test');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.version).toBe(1);
+      expect(result[1]?.version).toBe(2);
+    });
+
+    it('returns empty array when no history exists', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await manager.getVersions('nonexistent');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/suite/SuiteManager.ts
+++ b/packages/core/src/suite/SuiteManager.ts
@@ -1,0 +1,78 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { SuiteEntry } from './SuiteEntry.js';
+
+export class SuiteManager {
+  private readonly suiteDir: string;
+
+  constructor(private readonly baseDir: string) {
+    this.suiteDir = join(baseDir, '.ppia', 'suite');
+  }
+
+  async save(entry: SuiteEntry): Promise<void> {
+    const testDir = join(this.suiteDir, entry.testName);
+    await mkdir(testDir, { recursive: true });
+
+    const latestPath = join(testDir, 'latest.json');
+    const historyPath = join(testDir, 'history.json');
+
+    // Write latest
+    await writeFile(latestPath, JSON.stringify(entry, null, 2), 'utf-8');
+
+    // Append to history
+    const history = await this.readHistory(historyPath);
+    history.push(entry);
+    await writeFile(historyPath, JSON.stringify(history, null, 2), 'utf-8');
+  }
+
+  async list(): Promise<SuiteEntry[]> {
+    const entries: SuiteEntry[] = [];
+
+    let dirNames: string[];
+    try {
+      dirNames = await readdir(this.suiteDir);
+    } catch {
+      return entries;
+    }
+
+    for (const name of dirNames) {
+      const entry = await this.readLatest(name);
+      if (entry) {
+        entries.push(entry);
+      }
+    }
+
+    return entries;
+  }
+
+  async getById(testName: string): Promise<SuiteEntry | undefined> {
+    return this.readLatest(testName);
+  }
+
+  async getVersions(testName: string): Promise<SuiteEntry[]> {
+    const historyPath = join(this.suiteDir, testName, 'history.json');
+    return this.readHistory(historyPath);
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────
+
+  private async readLatest(testName: string): Promise<SuiteEntry | undefined> {
+    const latestPath = join(this.suiteDir, testName, 'latest.json');
+    try {
+      const raw = await readFile(latestPath, 'utf-8');
+      return JSON.parse(raw) as SuiteEntry;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async readHistory(historyPath: string): Promise<SuiteEntry[]> {
+    try {
+      const raw = await readFile(historyPath, 'utf-8');
+      return JSON.parse(raw) as SuiteEntry[];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/core/src/suite/index.ts
+++ b/packages/core/src/suite/index.ts
@@ -1,1 +1,4 @@
-// Suite: test suite management, history and knowledge base client.
+export { KnowledgeBase } from './KnowledgeBase.js';
+export type { KnowledgeEntry, ResetOptions } from './KnowledgeEntry.js';
+export { SuiteManager } from './SuiteManager.js';
+export type { SuiteEntry, SuiteEntryArtifacts, SuiteEntryMetrics } from './SuiteEntry.js';


### PR DESCRIPTION
## Summary

- Add `SuiteManager` for persisting generated tests, artifacts and metrics to `.ppia/suite/<testName>/` (latest.json + history.json)
- Add `KnowledgeBase` for persisting validated selectors per URL to `.ppia/knowledge.json` with flexible reset (all, by URL, by path, deep)
- Add domain models: `SuiteEntry`, `SuiteEntryMetrics`, `SuiteEntryArtifacts`, `KnowledgeEntry`, `ResetOptions`
- 21 new tests (131 total), all passing

Closes #16

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] 131 vitest tests pass (21 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)