### PR TITLE
feat(cli): add ppia knowledge, suite and config commands

### DIFF
--- a/packages/core/src/cli/commands/config-cmd.ts
+++ b/packages/core/src/cli/commands/config-cmd.ts
@@ -1,0 +1,116 @@
+import { resolve } from 'node:path';
+
+import { Command } from 'commander';
+
+import {
+  loadProjectConfig,
+  ProjectConfigError,
+  resolveEnvVars,
+} from '../../config/ProjectConfig.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+async function configValidateAction(): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  try {
+    const config = await loadProjectConfig(configPath);
+    ui.success(`Config valid: ${config.projectName}`);
+    ui.listItem('Environments', String(config.environments.length));
+    ui.listItem('Users', String(config.users.length));
+    ui.listItem('Combinations', String(config.setupCombinations.length));
+    ui.blank();
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(`Validation failed: ${err.message}`);
+      if (err.field) {
+        ui.listItem('Field', err.field);
+      }
+    } else {
+      throw err;
+    }
+    process.exitCode = 1;
+  }
+}
+
+async function configSetupsAction(): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  try {
+    const config = await loadProjectConfig(configPath);
+
+    if (config.setupCombinations.length === 0) {
+      ui.info('No setup combinations defined. Run "ppia setup add" to create one.');
+      return;
+    }
+
+    ui.header(`${config.projectName} — Setup Status`);
+
+    for (const combo of config.setupCombinations) {
+      const env = config.environments.find((e) => e.name === combo.environment);
+      if (!env) {
+        ui.listItem(combo.environment, 'environment not found');
+        continue;
+      }
+
+      for (const userName of combo.users) {
+        const user = config.users.find((u) => u.name === userName);
+        if (!user) {
+          ui.listItem(`${combo.environment}/${userName}`, 'user not found');
+          continue;
+        }
+
+        const issues: string[] = [];
+        checkEnvVar(user.email, issues);
+        checkEnvVar(user.password, issues);
+
+        const status = issues.length === 0 ? 'ok' : issues.join(', ');
+        const icon = issues.length === 0 ? 'ok' : `missing: ${status}`;
+        ui.listItem(`${combo.environment}/${userName}`, icon);
+      }
+    }
+
+    ui.blank();
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(err.message);
+    } else {
+      throw err;
+    }
+    process.exitCode = 1;
+  }
+}
+
+function checkEnvVar(value: string | undefined, issues: string[]): void {
+  if (!value) {
+    return;
+  }
+  const envVarPattern = /\$\{([^}]+)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = envVarPattern.exec(value)) !== null) {
+    const varName = match[1];
+    if (varName) {
+      try {
+        resolveEnvVars(`\${${varName}}`);
+      } catch {
+        issues.push(`$\{${varName}}`);
+      }
+    }
+  }
+}
+
+export function createConfigCommand(): Command {
+  const config = new Command('config')
+    .description('Validate and inspect project configuration');
+
+  config
+    .command('validate')
+    .description('Validate ppia.yaml schema, env vars and setup references')
+    .action(configValidateAction);
+
+  config
+    .command('setups')
+    .description('List defined setups with environment variable status')
+    .action(configSetupsAction);
+
+  return config;
+}

--- a/packages/core/src/cli/commands/knowledge.ts
+++ b/packages/core/src/cli/commands/knowledge.ts
@@ -1,0 +1,106 @@
+import { resolve } from 'node:path';
+
+import { Command } from 'commander';
+
+import { KnowledgeBase } from '../../suite/KnowledgeBase.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+function createKb(): KnowledgeBase {
+  return new KnowledgeBase(resolve(process.cwd()));
+}
+
+async function knowledgeListAction(): Promise<void> {
+  const kb = createKb();
+  const entries = await kb.getAll();
+
+  if (entries.length === 0) {
+    ui.info('No knowledge entries yet. Run "ppia generate" to start learning.');
+    return;
+  }
+
+  const byUrl = new Map<string, number>();
+  for (const entry of entries) {
+    byUrl.set(entry.url, (byUrl.get(entry.url) ?? 0) + 1);
+  }
+
+  ui.header('Knowledge Base');
+  for (const [url, count] of byUrl) {
+    ui.listItem(url, `${String(count)} selector${count > 1 ? 's' : ''}`);
+  }
+  ui.blank();
+}
+
+async function knowledgeShowAction(opts: Record<string, unknown>): Promise<void> {
+  const url = typeof opts.url === 'string' ? opts.url : undefined;
+  if (!url) {
+    ui.error('--url is required. Usage: ppia knowledge show --url <url>');
+    process.exitCode = 1;
+    return;
+  }
+
+  const kb = createKb();
+  const entries = await kb.getByUrl(url);
+
+  if (entries.length === 0) {
+    ui.info(`No selectors known for "${url}".`);
+    return;
+  }
+
+  ui.header(`Selectors for ${url}`);
+  for (const entry of entries) {
+    ui.subheader(entry.elementDescription);
+    ui.listItem('Reliable', entry.reliableSelector);
+    if (entry.problematicSelectors.length > 0) {
+      ui.listItem('Problematic', entry.problematicSelectors.join(', '));
+    }
+    ui.listItem('Learned from', `${entry.learnedFrom} (${entry.learnedAt})`);
+  }
+  ui.blank();
+}
+
+async function knowledgeResetAction(opts: Record<string, unknown>): Promise<void> {
+  const kb = createKb();
+  const url = typeof opts.url === 'string' ? opts.url : undefined;
+  const path = typeof opts.path === 'string' ? opts.path : undefined;
+  const deep = opts.deep === true;
+
+  const count = await kb.reset(
+    url ?? path ? { url, path, deep } : undefined,
+  );
+
+  if (count === 0) {
+    ui.info('Nothing to reset.');
+  } else {
+    ui.success(`Removed ${String(count)} knowledge entr${count > 1 ? 'ies' : 'y'}.`);
+  }
+}
+
+export function createKnowledgeCommand(): Command {
+  const knowledge = new Command('knowledge')
+    .description('View and manage the learned selectors knowledge base');
+
+  knowledge
+    .command('list')
+    .description('List known URLs with selector count')
+    .action(knowledgeListAction);
+
+  knowledge
+    .command('show')
+    .description('Show validated selectors for a URL')
+    .option('--url <url>', 'URL to show selectors for')
+    .action(async (opts: Record<string, unknown>) => {
+      await knowledgeShowAction(opts);
+    });
+
+  knowledge
+    .command('reset')
+    .description('Reset knowledge entries')
+    .option('--url <url>', 'Exact URL to reset')
+    .option('--path <path>', 'Path to reset')
+    .option('--deep', 'Include sub-paths when using --path')
+    .action(async (opts: Record<string, unknown>) => {
+      await knowledgeResetAction(opts);
+    });
+
+  return knowledge;
+}

--- a/packages/core/src/cli/commands/suite-cmd.ts
+++ b/packages/core/src/cli/commands/suite-cmd.ts
@@ -1,0 +1,148 @@
+import { resolve } from 'node:path';
+
+import { Command } from 'commander';
+
+import { SuiteManager } from '../../suite/SuiteManager.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+function createManager(): SuiteManager {
+  return new SuiteManager(resolve(process.cwd()));
+}
+
+function parseDuration(value: string): number | undefined {
+  const match = /^(\d+)d$/.exec(value);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  return parseInt(match[1], 10);
+}
+
+async function suiteListAction(): Promise<void> {
+  const manager = createManager();
+  const entries = await manager.list();
+
+  if (entries.length === 0) {
+    ui.info('No tests generated yet. Run "ppia generate" to create your first test.');
+    return;
+  }
+
+  ui.header('Generated Tests');
+  for (const entry of entries) {
+    const date = entry.createdAt.split('T')[0] ?? entry.createdAt;
+    ui.listItem(
+      entry.testName,
+      `v${String(entry.version)} | ${date} | ${entry.metrics.modelStrong} | ${ui.formatTokens(entry.metrics.totalTokensUsed)}`,
+    );
+  }
+  ui.blank();
+}
+
+async function suiteShowAction(testName: string): Promise<void> {
+  const manager = createManager();
+  const entry = await manager.getById(testName);
+
+  if (!entry) {
+    ui.error(`Test "${testName}" not found in suite.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  ui.header(`Test: ${entry.testName}`);
+  ui.listItem('Description', entry.description);
+  ui.listItem('URL', entry.url);
+  ui.listItem('Version', String(entry.version));
+  ui.listItem('Created', entry.createdAt);
+  if (entry.testFilePath) {
+    ui.listItem('File', entry.testFilePath);
+  }
+
+  ui.subheader('Metrics');
+  ui.listItem('Tokens', ui.formatTokens(entry.metrics.totalTokensUsed));
+  ui.listItem('Cost', ui.formatCost(entry.metrics.totalCost));
+  ui.listItem('Models', `${entry.metrics.modelFast} / ${entry.metrics.modelStrong}`);
+  ui.listItem('Exploration', `${String(entry.metrics.explorationRounds)} rounds`);
+  ui.listItem('Generation', `${String(entry.metrics.generationAttempts)} attempt${entry.metrics.generationAttempts > 1 ? 's' : ''}`);
+
+  ui.subheader('Test Code');
+  console.log(entry.testCode);
+
+  ui.blank();
+}
+
+async function suiteVersionsAction(testName: string): Promise<void> {
+  const manager = createManager();
+  const versions = await manager.getVersions(testName);
+
+  if (versions.length === 0) {
+    ui.error(`No versions found for "${testName}".`);
+    process.exitCode = 1;
+    return;
+  }
+
+  ui.header(`Versions: ${testName}`);
+  for (const entry of versions) {
+    const date = entry.createdAt.split('T')[0] ?? entry.createdAt;
+    ui.listItem(
+      `v${String(entry.version)}`,
+      `${date} | ${ui.formatTokens(entry.metrics.totalTokensUsed)} | ${ui.formatCost(entry.metrics.totalCost)}`,
+    );
+  }
+  ui.blank();
+}
+
+async function suiteCleanAction(opts: Record<string, unknown>): Promise<void> {
+  const olderThan = typeof opts.olderThan === 'string' ? opts.olderThan : undefined;
+  if (!olderThan) {
+    ui.error('--older-than is required. Usage: ppia suite clean --older-than 30d');
+    process.exitCode = 1;
+    return;
+  }
+
+  const days = parseDuration(olderThan);
+  if (days === undefined) {
+    ui.error(`Invalid duration "${olderThan}". Use format: <number>d (e.g., 30d)`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const manager = createManager();
+  const removed = await manager.clean(days);
+
+  if (removed === 0) {
+    ui.info('No tests older than the specified threshold.');
+  } else {
+    ui.success(`Removed ${String(removed)} test${removed > 1 ? 's' : ''}.`);
+  }
+}
+
+export function createSuiteCommand(): Command {
+  const suite = new Command('suite')
+    .description('View and manage generated test history');
+
+  suite
+    .command('list')
+    .description('List all generated tests')
+    .action(suiteListAction);
+
+  suite
+    .command('show')
+    .description('Show details of a generated test')
+    .argument('<testName>', 'Name of the test to show')
+    .action(suiteShowAction);
+
+  suite
+    .command('versions')
+    .description('Show version history of a test')
+    .argument('<testName>', 'Name of the test')
+    .action(suiteVersionsAction);
+
+  suite
+    .command('clean')
+    .description('Remove old tests from the suite')
+    .option('--older-than <duration>', 'Remove tests older than duration (e.g., 30d)')
+    .action(async (opts: Record<string, unknown>) => {
+      await suiteCleanAction(opts);
+    });
+
+  return suite;
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -2,8 +2,11 @@
 
 import { Command } from 'commander';
 
+import { createConfigCommand } from './commands/config-cmd.js';
 import { registerGenerateCommand } from './commands/generate.js';
+import { createKnowledgeCommand } from './commands/knowledge.js';
 import { createSetupCommand } from './commands/setup.js';
+import { createSuiteCommand } from './commands/suite-cmd.js';
 
 const program = new Command();
 
@@ -14,6 +17,9 @@ program
 
 registerGenerateCommand(program);
 program.addCommand(createSetupCommand());
+program.addCommand(createKnowledgeCommand());
+program.addCommand(createSuiteCommand());
+program.addCommand(createConfigCommand());
 
 program.parseAsync().catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/suite/SuiteManager.test.ts
+++ b/packages/core/src/suite/SuiteManager.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
@@ -6,6 +6,7 @@ vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),
   readdir: vi.fn(),
   readFile: vi.fn(),
+  rm: vi.fn(),
   writeFile: vi.fn(),
 }));
 
@@ -15,6 +16,7 @@ import { SuiteManager } from './SuiteManager.js';
 const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
 const mockReaddir = readdir as unknown as ReturnType<typeof vi.fn>;
 const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+const mockRm = rm as unknown as ReturnType<typeof vi.fn>;
 const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
 
 function createEntry(overrides: Partial<SuiteEntry> = {}): SuiteEntry {
@@ -161,6 +163,48 @@ describe('SuiteManager', () => {
       const result = await manager.getVersions('nonexistent');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('clean', () => {
+    it('removes tests older than the specified number of days', async () => {
+      const oldDate = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+      const recentDate = new Date().toISOString();
+      const oldEntry = createEntry({ testName: 'old-test', createdAt: oldDate });
+      const recentEntry = createEntry({ testName: 'recent-test', createdAt: recentDate });
+
+      mockReaddir.mockResolvedValueOnce(['old-test', 'recent-test']);
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(oldEntry))
+        .mockResolvedValueOnce(JSON.stringify(recentEntry));
+
+      const removed = await manager.clean(30);
+
+      expect(removed).toBe(1);
+      expect(mockRm).toHaveBeenCalledTimes(1);
+      expect(mockRm).toHaveBeenCalledWith(
+        join(baseDir, '.ppia', 'suite', 'old-test'),
+        { recursive: true, force: true },
+      );
+    });
+
+    it('returns 0 when no tests are older than threshold', async () => {
+      const recentEntry = createEntry({ createdAt: new Date().toISOString() });
+      mockReaddir.mockResolvedValueOnce(['recent-test']);
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(recentEntry));
+
+      const removed = await manager.clean(30);
+
+      expect(removed).toBe(0);
+      expect(mockRm).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 when suite directory does not exist', async () => {
+      mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const removed = await manager.clean(30);
+
+      expect(removed).toBe(0);
     });
   });
 });

--- a/packages/core/src/suite/SuiteManager.ts
+++ b/packages/core/src/suite/SuiteManager.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { SuiteEntry } from './SuiteEntry.js';
@@ -53,6 +53,33 @@ export class SuiteManager {
   async getVersions(testName: string): Promise<SuiteEntry[]> {
     const historyPath = join(this.suiteDir, testName, 'history.json');
     return this.readHistory(historyPath);
+  }
+
+  async clean(olderThanDays: number): Promise<number> {
+    const cutoff = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
+    let removed = 0;
+
+    let dirNames: string[];
+    try {
+      dirNames = await readdir(this.suiteDir);
+    } catch {
+      return 0;
+    }
+
+    for (const name of dirNames) {
+      const latest = await this.readLatest(name);
+      if (!latest) {
+        continue;
+      }
+
+      const createdMs = new Date(latest.createdAt).getTime();
+      if (createdMs < cutoff) {
+        await rm(join(this.suiteDir, name), { recursive: true, force: true });
+        removed++;
+      }
+    }
+
+    return removed;
   }
 
   // ── Private helpers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `ppia knowledge list/show/reset` — view and manage learned selectors
- Add `ppia suite list/show/versions/clean` — view and manage generated test history
- Add `ppia config validate/setups` — validate ppia.yaml and check env var status
- Add `SuiteManager.clean(olderThanDays)` for removing old test entries
- 3 new tests for clean() (134 total)

Closes #18

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] 134 vitest tests pass (3 new for clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)