### PR TITLE
chore(framework): remove TS placeholder test, add pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,5 +3,14 @@
   "private": true,
   "version": "0.1.0",
   "description": "Monorepo for playwright-ppia framework",
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4",
+  "scripts": {
+    "prepare": "simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-push": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 20 --silent && cd packages/core && pnpm lint && pnpm typecheck && pnpm test"
+  },
+  "devDependencies": {
+    "simple-git-hooks": "^2.13.1"
+  }
 }

--- a/packages/core/src/__tests__/placeholder.test.ts
+++ b/packages/core/src/__tests__/placeholder.test.ts
@@ -1,9 +1,0 @@
-import { describe, it } from 'vitest';
-
-describe('placeholder', () => {
-  it('PLACEHOLDER — eliminar al completar T19', () => {
-    throw new Error(
-      'Tests unitarios no implementados. Completa T19 antes de mergear a master.',
-    );
-  });
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
 
   packages/core:
     dependencies:
@@ -1034,6 +1038,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2092,6 +2100,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

- Remove TypeScript placeholder test (T18 defense) — 134 real tests cover all modules
- Add `simple-git-hooks` pre-push hook: `lint + typecheck + test` before every push
- Hook sources nvm to ensure correct Node.js version

Closes #20

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] 134 vitest tests pass
- [x] Pre-push hook runs and blocks push on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)