### PR TITLE
chore(ai-service): remove Python placeholder, extend pre-push hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "pre-push": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 20 --silent && cd packages/core && pnpm lint && pnpm typecheck && pnpm test"
+    "pre-push": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 20 --silent && cd packages/core && pnpm lint && pnpm typecheck && pnpm test && cd python && . .venv/bin/activate && ruff check src && mypy --strict src && pytest"
   },
   "devDependencies": {
     "simple-git-hooks": "^2.13.1"

--- a/packages/core/python/pyproject.toml
+++ b/packages/core/python/pyproject.toml
@@ -33,3 +33,4 @@ select = ["E", "F", "I", "N", "UP", "B", "SIM"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/core/python/tests/test_placeholder.py
+++ b/packages/core/python/tests/test_placeholder.py
@@ -1,7 +1,0 @@
-import pytest
-
-
-def test_placeholder() -> None:
-    pytest.fail(
-        "Tests unitarios no implementados. Completa T20 antes de mergear a master."
-    )


### PR DESCRIPTION
## Summary

- Remove Python placeholder test — 42 real tests cover all AI service modules
- Extend pre-push hook with Python QA: `ruff check + mypy --strict + pytest`
- Add `asyncio_mode = "auto"` to pyproject.toml (eliminates asyncio warnings)

Closes #21

## Test plan

- [x] `ruff check`: clean
- [x] `mypy --strict`: clean
- [x] 42 pytest tests pass
- [x] 134 vitest tests pass
- [x] Pre-push hook runs full TS + Python QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)