### PR TITLE
feat(cli): add ppia init with interactive AI configuration

### DIFF
--- a/packages/core/src/cli/commands/generate.ts
+++ b/packages/core/src/cli/commands/generate.ts
@@ -12,7 +12,7 @@ import { SetupAgent } from '../../agents/SetupAgent.js';
 import { ActionExecutor } from '../../browser/ActionExecutor.js';
 import { BrowserManager } from '../../browser/BrowserManager.js';
 import { HtmlExtractor } from '../../browser/HtmlExtractor.js';
-import { loadProjectConfig } from '../../config/ProjectConfig.js';
+import { DEFAULT_AI_CONFIG, loadProjectConfig } from '../../config/ProjectConfig.js';
 import { SetupManager } from '../../config/SetupManager.js';
 import { createAgentContext } from '../../domain/AgentContext.js';
 import { TestExecutor } from '../../executor/TestExecutor.js';
@@ -47,10 +47,19 @@ async function generateAction(description: string, options: GenerateOptions): Pr
   const outputDir = resolve(process.cwd(), 'output');
   const configPath = resolve(process.cwd(), 'ppia.yaml');
 
+  // ── Load AI config from ppia.yaml (fallback to defaults) ──────────
+  let modelFast = DEFAULT_AI_CONFIG.exploration.model;
+  let modelStrong = DEFAULT_AI_CONFIG.generation.model;
+  try {
+    const config = await loadProjectConfig(configPath);
+    modelFast = config.ai.exploration.model;
+    modelStrong = config.ai.generation.model;
+  } catch {
+    // No config or invalid — use defaults
+  }
+
   const pythonServer = new PythonServerManager();
   const browser = new BrowserManager({ headless: false });
-  const modelFast = 'gpt-4o-mini';
-  const modelStrong = 'gpt-4o';
   let totalTokens = 0;
   let totalCost = 0;
 

--- a/packages/core/src/cli/commands/init.ts
+++ b/packages/core/src/cli/commands/init.ts
@@ -1,0 +1,222 @@
+import { access, readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { Command } from 'commander';
+import { confirm, input, select } from '@inquirer/prompts';
+
+import type { AiProvider } from '../../config/ProjectConfig.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const OPENAI_MODELS = ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'] as const;
+const ANTHROPIC_MODELS = ['claude-haiku-4-20250414', 'claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022'] as const;
+
+interface ModelChoice {
+  provider: AiProvider;
+  model: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detectProjectName(cwd: string): Promise<string> {
+  try {
+    const raw = await readFile(resolve(cwd, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(raw) as { name?: string };
+    return typeof pkg.name === 'string' ? pkg.name : 'my-project';
+  } catch {
+    return 'my-project';
+  }
+}
+
+async function detectBaseUrl(cwd: string): Promise<string | undefined> {
+  try {
+    const content = await readFile(resolve(cwd, 'playwright.config.ts'), 'utf-8');
+    const match = /baseURL:\s*['"]([^'"]+)['"]/.exec(content);
+    return match ? match[1] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildModelChoices(): Array<{ name: string; value: ModelChoice }> {
+  const choices: Array<{ name: string; value: ModelChoice }> = [];
+  for (const model of OPENAI_MODELS) {
+    choices.push({ name: `OpenAI — ${model}`, value: { provider: 'openai', model } });
+  }
+  for (const model of ANTHROPIC_MODELS) {
+    choices.push({ name: `Anthropic — ${model}`, value: { provider: 'anthropic', model } });
+  }
+  return choices;
+}
+
+function generateYaml(
+  projectName: string,
+  exploration: ModelChoice,
+  generation: ModelChoice,
+  baseUrl?: string,
+): string {
+  let yaml = `project:\n  name: ${projectName}\n\n`;
+  yaml += `ai:\n`;
+  yaml += `  exploration:\n    provider: ${exploration.provider}\n    model: ${exploration.model}\n`;
+  yaml += `  generation:\n    provider: ${generation.provider}\n    model: ${generation.model}\n`;
+
+  if (baseUrl) {
+    yaml += `\nenvironments:\n  - name: default\n    base_url: ${baseUrl}\n`;
+  }
+
+  return yaml;
+}
+
+function generateEnv(keys: { openai?: string; anthropic?: string }): string {
+  const lines: string[] = ['# ppia — AI Service configuration'];
+  if (keys.openai) {
+    lines.push(`OPENAI_API_KEY=${keys.openai}`);
+  }
+  if (keys.anthropic) {
+    lines.push(`ANTHROPIC_API_KEY=${keys.anthropic}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+// ── Main action ─────────────────────────────────────────────────────
+
+async function initAction(): Promise<void> {
+  const cwd = process.cwd();
+
+  ui.header('ppia init');
+
+  // Check existing config
+  const configPath = resolve(cwd, 'ppia.yaml');
+  if (await fileExists(configPath)) {
+    const overwrite = await confirm({
+      message: 'ppia.yaml already exists. Overwrite?',
+      default: false,
+    });
+    if (!overwrite) {
+      ui.info('Init cancelled.');
+      return;
+    }
+  }
+
+  // Project name
+  const detectedName = await detectProjectName(cwd);
+  const projectName = await input({
+    message: 'Project name:',
+    default: detectedName,
+  });
+
+  // Model choices
+  const modelChoices = buildModelChoices();
+
+  ui.blank();
+  ui.info('Select the AI model for each phase. You can mix providers freely.');
+  ui.blank();
+
+  const exploration = await select<ModelChoice>({
+    message: 'Model for exploration (fast, many calls):',
+    choices: modelChoices,
+    default: { provider: 'openai' as const, model: 'gpt-4o-mini' },
+  });
+
+  const generation = await select<ModelChoice>({
+    message: 'Model for generation (strong, fewer calls):',
+    choices: modelChoices,
+    default: { provider: 'openai' as const, model: 'gpt-4o' },
+  });
+
+  // Determine which API keys we need
+  const needsOpenai = exploration.provider === 'openai' || generation.provider === 'openai';
+  const needsAnthropic = exploration.provider === 'anthropic' || generation.provider === 'anthropic';
+
+  ui.blank();
+  const apiKeys: { openai?: string; anthropic?: string } = {};
+
+  if (needsOpenai) {
+    const existingKey = process.env['OPENAI_API_KEY'];
+    if (existingKey) {
+      ui.info(`OpenAI API key detected in environment (${existingKey.slice(0, 12)}...)`);
+      const useExisting = await confirm({
+        message: 'Use this key?',
+        default: true,
+      });
+      apiKeys.openai = useExisting
+        ? existingKey
+        : await input({ message: 'OpenAI API Key:' });
+    } else {
+      apiKeys.openai = await input({ message: 'OpenAI API Key:' });
+    }
+  }
+
+  if (needsAnthropic) {
+    const existingKey = process.env['ANTHROPIC_API_KEY'];
+    if (existingKey) {
+      ui.info(`Anthropic API key detected in environment (${existingKey.slice(0, 12)}...)`);
+      const useExisting = await confirm({
+        message: 'Use this key?',
+        default: true,
+      });
+      apiKeys.anthropic = useExisting
+        ? existingKey
+        : await input({ message: 'Anthropic API Key:' });
+    } else {
+      apiKeys.anthropic = await input({ message: 'Anthropic API Key:' });
+    }
+  }
+
+  // Detect baseURL
+  const baseUrl = await detectBaseUrl(cwd);
+  if (baseUrl) {
+    ui.info(`Detected baseURL from playwright.config.ts: ${baseUrl}`);
+  }
+
+  // Write files
+  const yamlContent = generateYaml(projectName, exploration, generation, baseUrl);
+  await writeFile(configPath, yamlContent, 'utf-8');
+  ui.success('Created ppia.yaml');
+
+  const envPath = resolve(cwd, '.env');
+  if (await fileExists(envPath)) {
+    const existingEnv = await readFile(envPath, 'utf-8');
+    const newKeys: string[] = [];
+    if (apiKeys.openai && !existingEnv.includes('OPENAI_API_KEY=')) {
+      newKeys.push(`OPENAI_API_KEY=${apiKeys.openai}`);
+    }
+    if (apiKeys.anthropic && !existingEnv.includes('ANTHROPIC_API_KEY=')) {
+      newKeys.push(`ANTHROPIC_API_KEY=${apiKeys.anthropic}`);
+    }
+    if (newKeys.length > 0) {
+      const appendContent = '\n# ppia — AI Service configuration\n' + newKeys.join('\n') + '\n';
+      await writeFile(envPath, existingEnv + appendContent, 'utf-8');
+      ui.success('Updated .env (appended API keys)');
+    } else {
+      ui.info('.env already contains the required API keys');
+    }
+  } else {
+    await writeFile(envPath, generateEnv(apiKeys), 'utf-8');
+    ui.success('Created .env');
+  }
+
+  ui.blank();
+  ui.success('Project initialized. Run `ppia generate "test description"` to start.');
+}
+
+// ── Command registration ────────────────────────────────────────────
+
+export function registerInitCommand(program: Command): void {
+  program
+    .command('init')
+    .description('Initialize ppia in a Playwright project (interactive setup)')
+    .action(async () => {
+      await initAction();
+    });
+}

--- a/packages/core/src/cli/commands/init.ts
+++ b/packages/core/src/cli/commands/init.ts
@@ -63,16 +63,13 @@ function generateYaml(
   projectName: string,
   exploration: ModelChoice,
   generation: ModelChoice,
-  baseUrl?: string,
+  baseUrl: string,
 ): string {
   let yaml = `project:\n  name: ${projectName}\n\n`;
   yaml += `ai:\n`;
   yaml += `  exploration:\n    provider: ${exploration.provider}\n    model: ${exploration.model}\n`;
   yaml += `  generation:\n    provider: ${generation.provider}\n    model: ${generation.model}\n`;
-
-  if (baseUrl) {
-    yaml += `\nenvironments:\n  - name: default\n    base_url: ${baseUrl}\n`;
-  }
+  yaml += `\nenvironments:\n  - name: default\n    base_url: ${baseUrl}\n`;
 
   return yaml;
 }
@@ -173,11 +170,12 @@ async function initAction(): Promise<void> {
     }
   }
 
-  // Detect baseURL
-  const baseUrl = await detectBaseUrl(cwd);
-  if (baseUrl) {
-    ui.info(`Detected baseURL from playwright.config.ts: ${baseUrl}`);
-  }
+  // Base URL
+  const detectedBaseUrl = await detectBaseUrl(cwd);
+  const baseUrl = await input({
+    message: 'Base URL for the project:',
+    default: detectedBaseUrl ?? 'https://example.com',
+  });
 
   // Write files
   const yamlContent = generateYaml(projectName, exploration, generation, baseUrl);

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 
 import { createConfigCommand } from './commands/config-cmd.js';
 import { registerGenerateCommand } from './commands/generate.js';
+import { registerInitCommand } from './commands/init.js';
 import { createKnowledgeCommand } from './commands/knowledge.js';
 import { createSetupCommand } from './commands/setup.js';
 import { createSuiteCommand } from './commands/suite-cmd.js';
@@ -15,6 +16,7 @@ program
   .description('AI-powered test generation for Playwright')
   .version('0.1.0');
 
+registerInitCommand(program);
 registerGenerateCommand(program);
 program.addCommand(createSetupCommand());
 program.addCommand(createKnowledgeCommand());

--- a/packages/core/src/config/ProjectConfig.ts
+++ b/packages/core/src/config/ProjectConfig.ts
@@ -32,8 +32,26 @@ export interface SetupCombination {
   users: string[];
 }
 
+export type AiProvider = 'openai' | 'anthropic';
+
+export interface AiModelConfig {
+  provider: AiProvider;
+  model: string;
+}
+
+export interface AiConfig {
+  exploration: AiModelConfig;
+  generation: AiModelConfig;
+}
+
+export const DEFAULT_AI_CONFIG: AiConfig = {
+  exploration: { provider: 'openai', model: 'gpt-4o-mini' },
+  generation: { provider: 'openai', model: 'gpt-4o' },
+};
+
 export interface ProjectConfig {
   projectName: string;
+  ai: AiConfig;
   environments: EnvironmentConfig[];
   users: UserConfig[];
   setupCombinations: SetupCombination[];
@@ -71,8 +89,19 @@ interface RawCombination {
   users?: unknown;
 }
 
+interface RawAiModelConfig {
+  provider?: unknown;
+  model?: unknown;
+}
+
+interface RawAiConfig {
+  exploration?: unknown;
+  generation?: unknown;
+}
+
 interface RawConfig {
   project?: { name?: unknown };
+  ai?: unknown;
   environments?: unknown[];
   users?: unknown[];
   setup_combinations?: unknown[];
@@ -188,6 +217,45 @@ function parseCombination(
   };
 }
 
+const VALID_AI_PROVIDERS: readonly AiProvider[] = ['openai', 'anthropic'];
+
+function parseAiModelConfig(
+  raw: unknown,
+  field: string,
+  fallback: AiModelConfig,
+): AiModelConfig {
+  if (!raw || typeof raw !== 'object') {
+    return fallback;
+  }
+  const obj = raw as RawAiModelConfig;
+  const provider = typeof obj.provider === 'string' && VALID_AI_PROVIDERS.includes(obj.provider as AiProvider)
+    ? (obj.provider as AiProvider)
+    : fallback.provider;
+  const model = typeof obj.model === 'string' && obj.model.length > 0
+    ? obj.model
+    : fallback.model;
+
+  if (typeof obj.provider === 'string' && !VALID_AI_PROVIDERS.includes(obj.provider as AiProvider)) {
+    throw new ProjectConfigError(
+      `ai.${field}.provider must be one of: ${VALID_AI_PROVIDERS.join(', ')}. Got: "${obj.provider}"`,
+      `ai.${field}.provider`,
+    );
+  }
+
+  return { provider, model };
+}
+
+function parseAiConfig(raw: unknown): AiConfig {
+  if (!raw || typeof raw !== 'object') {
+    return DEFAULT_AI_CONFIG;
+  }
+  const obj = raw as RawAiConfig;
+  return {
+    exploration: parseAiModelConfig(obj.exploration, 'exploration', DEFAULT_AI_CONFIG.exploration),
+    generation: parseAiModelConfig(obj.generation, 'generation', DEFAULT_AI_CONFIG.generation),
+  };
+}
+
 // ── Main ───────────────────────────────────────────────────────────────
 
 export async function loadProjectConfig(filePath: string): Promise<ProjectConfig> {
@@ -219,6 +287,8 @@ export async function loadProjectConfig(filePath: string): Promise<ProjectConfig
     );
   }
 
+  const ai = parseAiConfig(config.ai);
+
   const rawEnvironments = Array.isArray(config.environments) ? config.environments : [];
   const rawUsers = Array.isArray(config.users) ? config.users : [];
   const rawCombinations = Array.isArray(config.setup_combinations) ? config.setup_combinations : [];
@@ -239,6 +309,7 @@ export async function loadProjectConfig(filePath: string): Promise<ProjectConfig
 
   return {
     projectName,
+    ai,
     environments,
     users,
     setupCombinations,

--- a/packages/core/src/config/SetupManager.test.ts
+++ b/packages/core/src/config/SetupManager.test.ts
@@ -6,6 +6,7 @@ vi.mock('node:fs/promises', () => ({
 
 import { readFile } from 'node:fs/promises';
 
+import { DEFAULT_AI_CONFIG } from './ProjectConfig.js';
 import type { ProjectConfig } from './ProjectConfig.js';
 import { SetupManager } from './SetupManager.js';
 
@@ -14,6 +15,7 @@ const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
 function createConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
   return {
     projectName: 'test-app',
+    ai: DEFAULT_AI_CONFIG,
     environments: [
       { name: 'staging', baseUrl: 'https://staging.example.com' },
       { name: 'production', baseUrl: 'https://prod.example.com', cookies: '/path/to/cookies.json' },


### PR DESCRIPTION
## Summary
- Add `ppia init` interactive wizard: configure AI provider and model independently for exploration and generation phases
- Mix providers freely (e.g. OpenAI for exploration, Anthropic for generation)
- Detect project name from `package.json` and ask for base URL (pre-filled from `playwright.config.ts`)
- Generate `ppia.yaml` with AI config and `.env` with required API keys
- `generate` command reads models from `ppia.yaml` instead of hardcoding

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] 134 TypeScript tests pass
- [x] 42 Python tests pass
- [x] Pre-push hook green

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)