### PR TITLE
Release: T13-T26 — CLI completo, CI/CD, tests y ppia init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-        working-directory: .
+        working-directory: ${{ github.workspace }}
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ jobs:
         with:
           node-version: 20
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, master]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci-typescript:
+    name: TypeScript
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/core
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm typecheck
+
+      - name: Tests
+        run: pnpm test
+
+  ci-python:
+    name: Python
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/core/python
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Type check
+        run: mypy --strict src
+
+      - name: Tests
+        run: pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:
@@ -36,7 +34,12 @@ jobs:
         run: pnpm typecheck
 
       - name: Tests
+        run: pnpm test -- --exclude 'src/__tests__/placeholder.test.ts'
+        if: github.base_ref == 'develop'
+
+      - name: Tests (with placeholders)
         run: pnpm test
+        if: github.base_ref == 'master'
 
   ci-python:
     name: Python
@@ -63,4 +66,9 @@ jobs:
         run: mypy --strict src
 
       - name: Tests
+        run: pytest --ignore=tests/test_placeholder.py
+        if: github.base_ref == 'develop'
+
+      - name: Tests (with placeholders)
         run: pytest
+        if: github.base_ref == 'master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Bump version & tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine version bump
+        id: bump
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "last_tag=$LAST_TAG" >> "$GITHUB_OUTPUT"
+
+          COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
+
+          BUMP="patch"
+          if echo "$COMMITS" | grep -qE "^feat(\(.+\))?!:|^BREAKING CHANGE:"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
+            BUMP="minor"
+          fi
+
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+
+      - name: Bump version in package.json
+        id: version
+        working-directory: packages/core
+        run: |
+          NEW_VERSION=$(npm version "${{ steps.bump.outputs.bump }}" --no-git-tag-version)
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and tag
+        run: |
+          git add packages/core/package.json
+          git commit -m "chore(release): ${{ steps.version.outputs.new_version }}"
+          git tag "${{ steps.version.outputs.new_version }}"
+          git push origin master --follow-tags
+
+      - name: Publish npm (placeholder)
+        run: |
+          echo "npm publish will be enabled in T22"
+          echo "Version: ${{ steps.version.outputs.new_version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,8 @@ build/
 .cache/
 *.tsbuildinfo
 
-# npm / pnpm / bun
+# npm / bun
 package-lock.json
-pnpm-lock.yaml
 bun.lockb
 yarn.lock
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "simple-git-hooks"
   },
   "simple-git-hooks": {
-    "pre-push": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 20 --silent && cd packages/core && pnpm lint && pnpm typecheck && pnpm test"
+    "pre-push": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 20 --silent && cd packages/core && pnpm lint && pnpm typecheck && pnpm test && cd python && . .venv/bin/activate && ruff check src && mypy --strict src && pytest"
   },
   "devDependencies": {
     "simple-git-hooks": "^2.13.1"

--- a/package.json
+++ b/package.json
@@ -3,5 +3,14 @@
   "private": true,
   "version": "0.1.0",
   "description": "Monorepo for playwright-ppia framework",
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4",
+  "scripts": {
+    "prepare": "simple-git-hooks"
+  },
+  "simple-git-hooks": {
+    "pre-push": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 20 --silent && cd packages/core && pnpm lint && pnpm typecheck && pnpm test"
+  },
+  "devDependencies": {
+    "simple-git-hooks": "^2.13.1"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,9 @@
     "vitest": "^3.0.0"
   },
   "dependencies": {
+    "@inquirer/prompts": "^8.3.0",
+    "chalk": "^5.6.2",
+    "commander": "^14.0.3",
     "yaml": "^2.8.2"
   }
 }

--- a/packages/core/python/pyproject.toml
+++ b/packages/core/python/pyproject.toml
@@ -33,3 +33,4 @@ select = ["E", "F", "I", "N", "UP", "B", "SIM"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/packages/core/python/pyproject.toml
+++ b/packages/core/python/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.3.0",
+    "pytest-asyncio>=0.24.0",
     "mypy>=1.11.0",
     "ruff>=0.7.0",
 ]

--- a/packages/core/python/tests/test_placeholder.py
+++ b/packages/core/python/tests/test_placeholder.py
@@ -1,7 +1,0 @@
-import pytest
-
-
-def test_placeholder() -> None:
-    pytest.fail(
-        "Tests unitarios no implementados. Completa T20 antes de mergear a master."
-    )

--- a/packages/core/python/tests/test_placeholder.py
+++ b/packages/core/python/tests/test_placeholder.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_placeholder() -> None:
+    pytest.fail(
+        "Tests unitarios no implementados. Completa T20 antes de mergear a master."
+    )

--- a/packages/core/src/__tests__/placeholder.test.ts
+++ b/packages/core/src/__tests__/placeholder.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from 'vitest';
+
+describe('placeholder', () => {
+  it('PLACEHOLDER — eliminar al completar T19', () => {
+    throw new Error(
+      'Tests unitarios no implementados. Completa T19 antes de mergear a master.',
+    );
+  });
+});

--- a/packages/core/src/__tests__/placeholder.test.ts
+++ b/packages/core/src/__tests__/placeholder.test.ts
@@ -1,9 +1,0 @@
-import { describe, it } from 'vitest';
-
-describe('placeholder', () => {
-  it('PLACEHOLDER — eliminar al completar T19', () => {
-    throw new Error(
-      'Tests unitarios no implementados. Completa T19 antes de mergear a master.',
-    );
-  });
-});

--- a/packages/core/src/agents/ExplorationAgent.ts
+++ b/packages/core/src/agents/ExplorationAgent.ts
@@ -9,6 +9,8 @@ import type {
 } from '../domain/ExplorationReport.js';
 import type { Page } from 'playwright';
 
+export type ExplorationProgressCallback = (round: ExplorationRound) => void;
+
 export class ExplorationAgent {
   constructor(
     private readonly aiClient: AiServiceClient,
@@ -17,7 +19,10 @@ export class ExplorationAgent {
     private readonly page: Page,
   ) {}
 
-  async run(context: AgentContext): Promise<ExplorationReport> {
+  async run(
+    context: AgentContext,
+    onProgress?: ExplorationProgressCallback,
+  ): Promise<ExplorationReport> {
     const { sessionId } = await this.aiClient.createSession();
     const rounds: ExplorationRound[] = [];
     let completed = false;
@@ -58,6 +63,7 @@ export class ExplorationAgent {
         if (response.completed) {
           completed = true;
           rounds.push(round);
+          onProgress?.(round);
           break;
         }
 
@@ -76,6 +82,7 @@ export class ExplorationAgent {
         }
 
         rounds.push(round);
+        onProgress?.(round);
       }
 
       if (!completed) {

--- a/packages/core/src/agents/GenerationAgent.ts
+++ b/packages/core/src/agents/GenerationAgent.ts
@@ -4,13 +4,24 @@ import type { AgentContext } from '../domain/AgentContext.js';
 import type { GenerationResult } from '../domain/GenerationResult.js';
 import type { TestExecutor } from '../executor/TestExecutor.js';
 
+export interface GenerationProgressEvent {
+  phase: 'test_generated' | 'test_passed' | 'test_failed' | 'artifacts_generated';
+  attempt: number;
+  tokensUsed: number;
+}
+
+export type GenerationProgressCallback = (event: GenerationProgressEvent) => void;
+
 export class GenerationAgent {
   constructor(
     private readonly aiClient: AiServiceClient,
     private readonly testExecutor: TestExecutor,
   ) {}
 
-  async run(context: AgentContext): Promise<GenerationResult> {
+  async run(
+    context: AgentContext,
+    onProgress?: GenerationProgressCallback,
+  ): Promise<GenerationResult> {
     if (!context.explorationReport) {
       throw new Error('GenerationAgent requires an explorationReport in context');
     }
@@ -37,14 +48,18 @@ export class GenerationAgent {
 
         const testResponse = await this.aiClient.generateTest(sessionId, request);
         totalTokensUsed += testResponse.tokensUsed;
+        onProgress?.({ phase: 'test_generated', attempt, tokensUsed: testResponse.tokensUsed });
 
         const result = await this.testExecutor.execute(testResponse.code, context.testName);
 
         if (result.passed) {
+          onProgress?.({ phase: 'test_passed', attempt, tokensUsed: 0 });
+
           const artifactsResponse = await this.aiClient.generateArtifacts(sessionId, {
             model: context.modelStrong,
           });
           totalTokensUsed += artifactsResponse.tokensUsed;
+          onProgress?.({ phase: 'artifacts_generated', attempt, tokensUsed: artifactsResponse.tokensUsed });
 
           return {
             generatedTest: {
@@ -63,6 +78,7 @@ export class GenerationAgent {
           };
         }
 
+        onProgress?.({ phase: 'test_failed', attempt, tokensUsed: 0 });
         lastFailedCode = testResponse.code;
         lastError = result.errorMessage ?? 'Test failed with unknown error';
       } finally {

--- a/packages/core/src/agents/index.ts
+++ b/packages/core/src/agents/index.ts
@@ -1,4 +1,6 @@
 export { ExplorationAgent } from './ExplorationAgent.js';
+export type { ExplorationProgressCallback } from './ExplorationAgent.js';
 export { GenerationAgent } from './GenerationAgent.js';
+export type { GenerationProgressCallback, GenerationProgressEvent } from './GenerationAgent.js';
 export { SetupAgent } from './SetupAgent.js';
 export type { SetupResult } from './SetupAgent.js';

--- a/packages/core/src/ai/AiServiceTypes.ts
+++ b/packages/core/src/ai/AiServiceTypes.ts
@@ -17,6 +17,7 @@ export interface PrepareInputResponse {
   objective: string;
   testName: string;
   parameters: Record<string, string>;
+  detectedUser?: string;
   tokensUsed: number;
 }
 

--- a/packages/core/src/cli/commands/config-cmd.ts
+++ b/packages/core/src/cli/commands/config-cmd.ts
@@ -1,0 +1,116 @@
+import { resolve } from 'node:path';
+
+import { Command } from 'commander';
+
+import {
+  loadProjectConfig,
+  ProjectConfigError,
+  resolveEnvVars,
+} from '../../config/ProjectConfig.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+async function configValidateAction(): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  try {
+    const config = await loadProjectConfig(configPath);
+    ui.success(`Config valid: ${config.projectName}`);
+    ui.listItem('Environments', String(config.environments.length));
+    ui.listItem('Users', String(config.users.length));
+    ui.listItem('Combinations', String(config.setupCombinations.length));
+    ui.blank();
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(`Validation failed: ${err.message}`);
+      if (err.field) {
+        ui.listItem('Field', err.field);
+      }
+    } else {
+      throw err;
+    }
+    process.exitCode = 1;
+  }
+}
+
+async function configSetupsAction(): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  try {
+    const config = await loadProjectConfig(configPath);
+
+    if (config.setupCombinations.length === 0) {
+      ui.info('No setup combinations defined. Run "ppia setup add" to create one.');
+      return;
+    }
+
+    ui.header(`${config.projectName} — Setup Status`);
+
+    for (const combo of config.setupCombinations) {
+      const env = config.environments.find((e) => e.name === combo.environment);
+      if (!env) {
+        ui.listItem(combo.environment, 'environment not found');
+        continue;
+      }
+
+      for (const userName of combo.users) {
+        const user = config.users.find((u) => u.name === userName);
+        if (!user) {
+          ui.listItem(`${combo.environment}/${userName}`, 'user not found');
+          continue;
+        }
+
+        const issues: string[] = [];
+        checkEnvVar(user.email, issues);
+        checkEnvVar(user.password, issues);
+
+        const status = issues.length === 0 ? 'ok' : issues.join(', ');
+        const icon = issues.length === 0 ? 'ok' : `missing: ${status}`;
+        ui.listItem(`${combo.environment}/${userName}`, icon);
+      }
+    }
+
+    ui.blank();
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(err.message);
+    } else {
+      throw err;
+    }
+    process.exitCode = 1;
+  }
+}
+
+function checkEnvVar(value: string | undefined, issues: string[]): void {
+  if (!value) {
+    return;
+  }
+  const envVarPattern = /\$\{([^}]+)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = envVarPattern.exec(value)) !== null) {
+    const varName = match[1];
+    if (varName) {
+      try {
+        resolveEnvVars(`\${${varName}}`);
+      } catch {
+        issues.push(`$\{${varName}}`);
+      }
+    }
+  }
+}
+
+export function createConfigCommand(): Command {
+  const config = new Command('config')
+    .description('Validate and inspect project configuration');
+
+  config
+    .command('validate')
+    .description('Validate ppia.yaml schema, env vars and setup references')
+    .action(configValidateAction);
+
+  config
+    .command('setups')
+    .description('List defined setups with environment variable status')
+    .action(configSetupsAction);
+
+  return config;
+}

--- a/packages/core/src/cli/commands/generate.ts
+++ b/packages/core/src/cli/commands/generate.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 
@@ -15,6 +16,7 @@ import { loadProjectConfig } from '../../config/ProjectConfig.js';
 import { SetupManager } from '../../config/SetupManager.js';
 import { createAgentContext } from '../../domain/AgentContext.js';
 import { TestExecutor } from '../../executor/TestExecutor.js';
+import { SuiteManager } from '../../suite/SuiteManager.js';
 import * as ui from '../ui/ProgressDisplay.js';
 
 // ── Types ─────────────────────────────────────────────────────────────
@@ -38,18 +40,6 @@ async function writeArtifacts(
   await writeFile(join(dir, `${testName}.cucumber.md`), artifacts.cucumberMd, 'utf-8');
 }
 
-async function writeMetrics(
-  outputDir: string,
-  testName: string,
-  metrics: Record<string, unknown>,
-): Promise<void> {
-  await mkdir(outputDir, { recursive: true });
-  await writeFile(
-    join(outputDir, `${testName}.metrics.json`),
-    JSON.stringify(metrics, null, 2),
-    'utf-8',
-  );
-}
 
 // ── Main action ───────────────────────────────────────────────────────
 
@@ -159,15 +149,27 @@ async function generateAction(description: string, options: GenerateOptions): Pr
     const testPath = genResult.generatedTest.filePath ?? join(outputDir, `${prepared.testName}.spec.ts`);
     await writeArtifacts(testPath, prepared.testName, genResult.generatedArtifacts);
 
-    // ── 9. Write metrics ──────────────────────────────────────────────
-    await writeMetrics(outputDir, prepared.testName, {
-      totalTokens,
-      totalCost,
-      modelFast,
-      modelStrong,
-      explorationRounds: explorationReport.totalRounds,
-      generationAttempts: genResult.attempts,
-      timestamp: new Date().toISOString(),
+    // ── 9. Save to suite ──────────────────────────────────────────────
+    const suiteManager = new SuiteManager(process.cwd());
+    await suiteManager.save({
+      id: randomUUID(),
+      testName: prepared.testName,
+      description: prepared.objective,
+      url: prepared.url,
+      testCode: genResult.generatedTest.code,
+      testFilePath: testPath,
+      artifacts: genResult.generatedArtifacts,
+      metrics: {
+        totalTokensUsed: totalTokens,
+        totalCost,
+        modelFast,
+        modelStrong,
+        explorationRounds: explorationReport.totalRounds,
+        generationAttempts: genResult.attempts,
+        timestamp: new Date().toISOString(),
+      },
+      version: 1,
+      createdAt: new Date().toISOString(),
     });
 
     // ── 10. Summary ───────────────────────────────────────────────────

--- a/packages/core/src/cli/commands/generate.ts
+++ b/packages/core/src/cli/commands/generate.ts
@@ -12,7 +12,7 @@ import { SetupAgent } from '../../agents/SetupAgent.js';
 import { ActionExecutor } from '../../browser/ActionExecutor.js';
 import { BrowserManager } from '../../browser/BrowserManager.js';
 import { HtmlExtractor } from '../../browser/HtmlExtractor.js';
-import { loadProjectConfig } from '../../config/ProjectConfig.js';
+import { DEFAULT_AI_CONFIG, loadProjectConfig } from '../../config/ProjectConfig.js';
 import { SetupManager } from '../../config/SetupManager.js';
 import { createAgentContext } from '../../domain/AgentContext.js';
 import { TestExecutor } from '../../executor/TestExecutor.js';
@@ -47,10 +47,19 @@ async function generateAction(description: string, options: GenerateOptions): Pr
   const outputDir = resolve(process.cwd(), 'output');
   const configPath = resolve(process.cwd(), 'ppia.yaml');
 
+  // ── Load AI config from ppia.yaml (fallback to defaults) ──────────
+  let modelFast = DEFAULT_AI_CONFIG.exploration.model;
+  let modelStrong = DEFAULT_AI_CONFIG.generation.model;
+  try {
+    const config = await loadProjectConfig(configPath);
+    modelFast = config.ai.exploration.model;
+    modelStrong = config.ai.generation.model;
+  } catch {
+    // No config or invalid — use defaults
+  }
+
   const pythonServer = new PythonServerManager();
   const browser = new BrowserManager({ headless: false });
-  const modelFast = 'gpt-4o-mini';
-  const modelStrong = 'gpt-4o';
   let totalTokens = 0;
   let totalCost = 0;
 

--- a/packages/core/src/cli/commands/generate.ts
+++ b/packages/core/src/cli/commands/generate.ts
@@ -1,0 +1,207 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+
+import type { Command } from 'commander';
+
+import { AiServiceClient } from '../../ai/AiServiceClient.js';
+import { PythonServerManager } from '../../ai/PythonServerManager.js';
+import { ExplorationAgent } from '../../agents/ExplorationAgent.js';
+import { GenerationAgent } from '../../agents/GenerationAgent.js';
+import { SetupAgent } from '../../agents/SetupAgent.js';
+import { ActionExecutor } from '../../browser/ActionExecutor.js';
+import { BrowserManager } from '../../browser/BrowserManager.js';
+import { HtmlExtractor } from '../../browser/HtmlExtractor.js';
+import { loadProjectConfig } from '../../config/ProjectConfig.js';
+import { SetupManager } from '../../config/SetupManager.js';
+import { createAgentContext } from '../../domain/AgentContext.js';
+import { TestExecutor } from '../../executor/TestExecutor.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+interface GenerateOptions {
+  setup?: string;
+  user?: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+async function writeArtifacts(
+  testFilePath: string,
+  testName: string,
+  artifacts: { pomMd: string; gherkinMd: string; cucumberMd: string },
+): Promise<void> {
+  const dir = dirname(testFilePath);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, `${testName}.pom.md`), artifacts.pomMd, 'utf-8');
+  await writeFile(join(dir, `${testName}.gherkin.md`), artifacts.gherkinMd, 'utf-8');
+  await writeFile(join(dir, `${testName}.cucumber.md`), artifacts.cucumberMd, 'utf-8');
+}
+
+async function writeMetrics(
+  outputDir: string,
+  testName: string,
+  metrics: Record<string, unknown>,
+): Promise<void> {
+  await mkdir(outputDir, { recursive: true });
+  await writeFile(
+    join(outputDir, `${testName}.metrics.json`),
+    JSON.stringify(metrics, null, 2),
+    'utf-8',
+  );
+}
+
+// ── Main action ───────────────────────────────────────────────────────
+
+async function generateAction(description: string, options: GenerateOptions): Promise<void> {
+  const outputDir = resolve(process.cwd(), 'output');
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  const pythonServer = new PythonServerManager();
+  const browser = new BrowserManager({ headless: false });
+  const modelFast = 'gpt-4o-mini';
+  const modelStrong = 'gpt-4o';
+  let totalTokens = 0;
+  let totalCost = 0;
+
+  try {
+    // ── 1. Start AI Service ───────────────────────────────────────────
+    ui.header('ppia generate');
+    ui.info('Starting AI Service...');
+    await pythonServer.start();
+    const aiClient = new AiServiceClient(pythonServer.baseUrl);
+    ui.success('AI Service ready');
+
+    // ── 2. Session 0: parse input ─────────────────────────────────────
+    const prepared = await aiClient.prepareInput({ rawInput: description });
+    totalTokens += prepared.tokensUsed;
+    totalCost += ui.estimateCost(modelFast, prepared.tokensUsed);
+    ui.phaseRow('Session 0', 'input analysis', modelFast, prepared.tokensUsed);
+
+    // ── 3. Build context ──────────────────────────────────────────────
+    let context = createAgentContext({
+      rawInput: description,
+      url: prepared.url,
+      objective: prepared.objective,
+      testName: prepared.testName,
+      parameters: prepared.parameters,
+      modelFast,
+      modelStrong,
+    });
+
+    // ── 4. Launch browser ─────────────────────────────────────────────
+    ui.info('Launching browser...');
+    const page = await browser.launch();
+    const actionExecutor = new ActionExecutor(page);
+    const htmlExtractor = new HtmlExtractor();
+
+    // ── 5. Setup (optional) ───────────────────────────────────────────
+    const detectedUser = prepared.detectedUser ?? options.user;
+    if (detectedUser) {
+      try {
+        const config = await loadProjectConfig(configPath);
+        const setupManager = new SetupManager(config, actionExecutor, page);
+        const setupAgent = new SetupAgent(setupManager);
+        const setupResult = await setupAgent.run(context, detectedUser, options.setup);
+        if (setupResult.authenticated) {
+          context = setupResult.context;
+          ui.success(`Authenticated as "${detectedUser}"`);
+        } else {
+          ui.warn(`User "${detectedUser}" not found in config, continuing without setup`);
+        }
+      } catch {
+        ui.warn('Setup config not available, continuing without authentication');
+      }
+    }
+
+    // ── 6. Exploration (Session A) ────────────────────────────────────
+    ui.blank();
+    const explorationAgent = new ExplorationAgent(aiClient, htmlExtractor, actionExecutor, page);
+
+    const explorationReport = await explorationAgent.run(context, (round) => {
+      totalTokens += round.tokensUsed;
+      totalCost += ui.estimateCost(modelFast, round.tokensUsed);
+      const detail = round.actionError
+        ? `round ${String(round.round)} (err)`
+        : `round ${String(round.round)}`;
+      ui.phaseRow('Exploration', detail, modelFast, round.tokensUsed);
+    });
+
+    ui.success(`Exploration completed in ${String(explorationReport.totalRounds)} rounds`);
+
+    // ── 7. Generation (Session B) ─────────────────────────────────────
+    ui.blank();
+    const genContext = { ...context, explorationReport };
+    const testExecutor = new TestExecutor(outputDir);
+    const generationAgent = new GenerationAgent(aiClient, testExecutor);
+
+    const genResult = await generationAgent.run(genContext, (event) => {
+      totalTokens += event.tokensUsed;
+      totalCost += ui.estimateCost(modelStrong, event.tokensUsed);
+
+      switch (event.phase) {
+        case 'test_generated':
+          ui.phaseRow('Generation', `attempt ${String(event.attempt)}`, modelStrong, event.tokensUsed);
+          break;
+        case 'test_failed':
+          ui.warn(`Test attempt ${String(event.attempt)} failed, retrying...`);
+          break;
+        case 'test_passed':
+          ui.success(`Test passed on attempt ${String(event.attempt)}`);
+          break;
+        case 'artifacts_generated':
+          ui.phaseRow('Artifacts', 'POM+Gherkin', modelStrong, event.tokensUsed);
+          break;
+      }
+    });
+
+    // ── 8. Write artifacts ────────────────────────────────────────────
+    const testPath = genResult.generatedTest.filePath ?? join(outputDir, `${prepared.testName}.spec.ts`);
+    await writeArtifacts(testPath, prepared.testName, genResult.generatedArtifacts);
+
+    // ── 9. Write metrics ──────────────────────────────────────────────
+    await writeMetrics(outputDir, prepared.testName, {
+      totalTokens,
+      totalCost,
+      modelFast,
+      modelStrong,
+      explorationRounds: explorationReport.totalRounds,
+      generationAttempts: genResult.attempts,
+      timestamp: new Date().toISOString(),
+    });
+
+    // ── 10. Summary ───────────────────────────────────────────────────
+    ui.separator();
+    ui.generateSummary({
+      totalTokens,
+      totalCost,
+      explorationRounds: explorationReport.totalRounds,
+      generationAttempts: genResult.attempts,
+      testPath,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ui.error(message);
+    process.exitCode = 1;
+  } finally {
+    await browser.close();
+    await pythonServer.stop();
+  }
+}
+
+// ── Command registration ──────────────────────────────────────────────
+
+export function registerGenerateCommand(program: Command): void {
+  program
+    .command('generate')
+    .description('Generate an E2E test from a natural language description')
+    .argument('<description>', 'Test description in natural language')
+    .option('-s, --setup <env>', 'Environment name for authentication setup')
+    .option('-u, --user <user>', 'User name for authentication')
+    .action(async (description: string, opts: Record<string, unknown>) => {
+      await generateAction(description, {
+        setup: typeof opts.setup === 'string' ? opts.setup : undefined,
+        user: typeof opts.user === 'string' ? opts.user : undefined,
+      });
+    });
+}

--- a/packages/core/src/cli/commands/init.ts
+++ b/packages/core/src/cli/commands/init.ts
@@ -1,0 +1,222 @@
+import { access, readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { Command } from 'commander';
+import { confirm, input, select } from '@inquirer/prompts';
+
+import type { AiProvider } from '../../config/ProjectConfig.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+// ── Constants ────────────────────────────────────────────────────────
+
+const OPENAI_MODELS = ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'] as const;
+const ANTHROPIC_MODELS = ['claude-haiku-4-20250414', 'claude-sonnet-4-20250514', 'claude-3-5-sonnet-20241022'] as const;
+
+interface ModelChoice {
+  provider: AiProvider;
+  model: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function detectProjectName(cwd: string): Promise<string> {
+  try {
+    const raw = await readFile(resolve(cwd, 'package.json'), 'utf-8');
+    const pkg = JSON.parse(raw) as { name?: string };
+    return typeof pkg.name === 'string' ? pkg.name : 'my-project';
+  } catch {
+    return 'my-project';
+  }
+}
+
+async function detectBaseUrl(cwd: string): Promise<string | undefined> {
+  try {
+    const content = await readFile(resolve(cwd, 'playwright.config.ts'), 'utf-8');
+    const match = /baseURL:\s*['"]([^'"]+)['"]/.exec(content);
+    return match ? match[1] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function buildModelChoices(): Array<{ name: string; value: ModelChoice }> {
+  const choices: Array<{ name: string; value: ModelChoice }> = [];
+  for (const model of OPENAI_MODELS) {
+    choices.push({ name: `OpenAI — ${model}`, value: { provider: 'openai', model } });
+  }
+  for (const model of ANTHROPIC_MODELS) {
+    choices.push({ name: `Anthropic — ${model}`, value: { provider: 'anthropic', model } });
+  }
+  return choices;
+}
+
+function generateYaml(
+  projectName: string,
+  exploration: ModelChoice,
+  generation: ModelChoice,
+  baseUrl?: string,
+): string {
+  let yaml = `project:\n  name: ${projectName}\n\n`;
+  yaml += `ai:\n`;
+  yaml += `  exploration:\n    provider: ${exploration.provider}\n    model: ${exploration.model}\n`;
+  yaml += `  generation:\n    provider: ${generation.provider}\n    model: ${generation.model}\n`;
+
+  if (baseUrl) {
+    yaml += `\nenvironments:\n  - name: default\n    base_url: ${baseUrl}\n`;
+  }
+
+  return yaml;
+}
+
+function generateEnv(keys: { openai?: string; anthropic?: string }): string {
+  const lines: string[] = ['# ppia — AI Service configuration'];
+  if (keys.openai) {
+    lines.push(`OPENAI_API_KEY=${keys.openai}`);
+  }
+  if (keys.anthropic) {
+    lines.push(`ANTHROPIC_API_KEY=${keys.anthropic}`);
+  }
+  return lines.join('\n') + '\n';
+}
+
+// ── Main action ─────────────────────────────────────────────────────
+
+async function initAction(): Promise<void> {
+  const cwd = process.cwd();
+
+  ui.header('ppia init');
+
+  // Check existing config
+  const configPath = resolve(cwd, 'ppia.yaml');
+  if (await fileExists(configPath)) {
+    const overwrite = await confirm({
+      message: 'ppia.yaml already exists. Overwrite?',
+      default: false,
+    });
+    if (!overwrite) {
+      ui.info('Init cancelled.');
+      return;
+    }
+  }
+
+  // Project name
+  const detectedName = await detectProjectName(cwd);
+  const projectName = await input({
+    message: 'Project name:',
+    default: detectedName,
+  });
+
+  // Model choices
+  const modelChoices = buildModelChoices();
+
+  ui.blank();
+  ui.info('Select the AI model for each phase. You can mix providers freely.');
+  ui.blank();
+
+  const exploration = await select<ModelChoice>({
+    message: 'Model for exploration (fast, many calls):',
+    choices: modelChoices,
+    default: { provider: 'openai' as const, model: 'gpt-4o-mini' },
+  });
+
+  const generation = await select<ModelChoice>({
+    message: 'Model for generation (strong, fewer calls):',
+    choices: modelChoices,
+    default: { provider: 'openai' as const, model: 'gpt-4o' },
+  });
+
+  // Determine which API keys we need
+  const needsOpenai = exploration.provider === 'openai' || generation.provider === 'openai';
+  const needsAnthropic = exploration.provider === 'anthropic' || generation.provider === 'anthropic';
+
+  ui.blank();
+  const apiKeys: { openai?: string; anthropic?: string } = {};
+
+  if (needsOpenai) {
+    const existingKey = process.env['OPENAI_API_KEY'];
+    if (existingKey) {
+      ui.info(`OpenAI API key detected in environment (${existingKey.slice(0, 12)}...)`);
+      const useExisting = await confirm({
+        message: 'Use this key?',
+        default: true,
+      });
+      apiKeys.openai = useExisting
+        ? existingKey
+        : await input({ message: 'OpenAI API Key:' });
+    } else {
+      apiKeys.openai = await input({ message: 'OpenAI API Key:' });
+    }
+  }
+
+  if (needsAnthropic) {
+    const existingKey = process.env['ANTHROPIC_API_KEY'];
+    if (existingKey) {
+      ui.info(`Anthropic API key detected in environment (${existingKey.slice(0, 12)}...)`);
+      const useExisting = await confirm({
+        message: 'Use this key?',
+        default: true,
+      });
+      apiKeys.anthropic = useExisting
+        ? existingKey
+        : await input({ message: 'Anthropic API Key:' });
+    } else {
+      apiKeys.anthropic = await input({ message: 'Anthropic API Key:' });
+    }
+  }
+
+  // Detect baseURL
+  const baseUrl = await detectBaseUrl(cwd);
+  if (baseUrl) {
+    ui.info(`Detected baseURL from playwright.config.ts: ${baseUrl}`);
+  }
+
+  // Write files
+  const yamlContent = generateYaml(projectName, exploration, generation, baseUrl);
+  await writeFile(configPath, yamlContent, 'utf-8');
+  ui.success('Created ppia.yaml');
+
+  const envPath = resolve(cwd, '.env');
+  if (await fileExists(envPath)) {
+    const existingEnv = await readFile(envPath, 'utf-8');
+    const newKeys: string[] = [];
+    if (apiKeys.openai && !existingEnv.includes('OPENAI_API_KEY=')) {
+      newKeys.push(`OPENAI_API_KEY=${apiKeys.openai}`);
+    }
+    if (apiKeys.anthropic && !existingEnv.includes('ANTHROPIC_API_KEY=')) {
+      newKeys.push(`ANTHROPIC_API_KEY=${apiKeys.anthropic}`);
+    }
+    if (newKeys.length > 0) {
+      const appendContent = '\n# ppia — AI Service configuration\n' + newKeys.join('\n') + '\n';
+      await writeFile(envPath, existingEnv + appendContent, 'utf-8');
+      ui.success('Updated .env (appended API keys)');
+    } else {
+      ui.info('.env already contains the required API keys');
+    }
+  } else {
+    await writeFile(envPath, generateEnv(apiKeys), 'utf-8');
+    ui.success('Created .env');
+  }
+
+  ui.blank();
+  ui.success('Project initialized. Run `ppia generate "test description"` to start.');
+}
+
+// ── Command registration ────────────────────────────────────────────
+
+export function registerInitCommand(program: Command): void {
+  program
+    .command('init')
+    .description('Initialize ppia in a Playwright project (interactive setup)')
+    .action(async () => {
+      await initAction();
+    });
+}

--- a/packages/core/src/cli/commands/init.ts
+++ b/packages/core/src/cli/commands/init.ts
@@ -63,16 +63,13 @@ function generateYaml(
   projectName: string,
   exploration: ModelChoice,
   generation: ModelChoice,
-  baseUrl?: string,
+  baseUrl: string,
 ): string {
   let yaml = `project:\n  name: ${projectName}\n\n`;
   yaml += `ai:\n`;
   yaml += `  exploration:\n    provider: ${exploration.provider}\n    model: ${exploration.model}\n`;
   yaml += `  generation:\n    provider: ${generation.provider}\n    model: ${generation.model}\n`;
-
-  if (baseUrl) {
-    yaml += `\nenvironments:\n  - name: default\n    base_url: ${baseUrl}\n`;
-  }
+  yaml += `\nenvironments:\n  - name: default\n    base_url: ${baseUrl}\n`;
 
   return yaml;
 }
@@ -173,11 +170,12 @@ async function initAction(): Promise<void> {
     }
   }
 
-  // Detect baseURL
-  const baseUrl = await detectBaseUrl(cwd);
-  if (baseUrl) {
-    ui.info(`Detected baseURL from playwright.config.ts: ${baseUrl}`);
-  }
+  // Base URL
+  const detectedBaseUrl = await detectBaseUrl(cwd);
+  const baseUrl = await input({
+    message: 'Base URL for the project:',
+    default: detectedBaseUrl ?? 'https://example.com',
+  });
 
   // Write files
   const yamlContent = generateYaml(projectName, exploration, generation, baseUrl);

--- a/packages/core/src/cli/commands/knowledge.ts
+++ b/packages/core/src/cli/commands/knowledge.ts
@@ -1,0 +1,106 @@
+import { resolve } from 'node:path';
+
+import { Command } from 'commander';
+
+import { KnowledgeBase } from '../../suite/KnowledgeBase.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+function createKb(): KnowledgeBase {
+  return new KnowledgeBase(resolve(process.cwd()));
+}
+
+async function knowledgeListAction(): Promise<void> {
+  const kb = createKb();
+  const entries = await kb.getAll();
+
+  if (entries.length === 0) {
+    ui.info('No knowledge entries yet. Run "ppia generate" to start learning.');
+    return;
+  }
+
+  const byUrl = new Map<string, number>();
+  for (const entry of entries) {
+    byUrl.set(entry.url, (byUrl.get(entry.url) ?? 0) + 1);
+  }
+
+  ui.header('Knowledge Base');
+  for (const [url, count] of byUrl) {
+    ui.listItem(url, `${String(count)} selector${count > 1 ? 's' : ''}`);
+  }
+  ui.blank();
+}
+
+async function knowledgeShowAction(opts: Record<string, unknown>): Promise<void> {
+  const url = typeof opts.url === 'string' ? opts.url : undefined;
+  if (!url) {
+    ui.error('--url is required. Usage: ppia knowledge show --url <url>');
+    process.exitCode = 1;
+    return;
+  }
+
+  const kb = createKb();
+  const entries = await kb.getByUrl(url);
+
+  if (entries.length === 0) {
+    ui.info(`No selectors known for "${url}".`);
+    return;
+  }
+
+  ui.header(`Selectors for ${url}`);
+  for (const entry of entries) {
+    ui.subheader(entry.elementDescription);
+    ui.listItem('Reliable', entry.reliableSelector);
+    if (entry.problematicSelectors.length > 0) {
+      ui.listItem('Problematic', entry.problematicSelectors.join(', '));
+    }
+    ui.listItem('Learned from', `${entry.learnedFrom} (${entry.learnedAt})`);
+  }
+  ui.blank();
+}
+
+async function knowledgeResetAction(opts: Record<string, unknown>): Promise<void> {
+  const kb = createKb();
+  const url = typeof opts.url === 'string' ? opts.url : undefined;
+  const path = typeof opts.path === 'string' ? opts.path : undefined;
+  const deep = opts.deep === true;
+
+  const count = await kb.reset(
+    url ?? path ? { url, path, deep } : undefined,
+  );
+
+  if (count === 0) {
+    ui.info('Nothing to reset.');
+  } else {
+    ui.success(`Removed ${String(count)} knowledge entr${count > 1 ? 'ies' : 'y'}.`);
+  }
+}
+
+export function createKnowledgeCommand(): Command {
+  const knowledge = new Command('knowledge')
+    .description('View and manage the learned selectors knowledge base');
+
+  knowledge
+    .command('list')
+    .description('List known URLs with selector count')
+    .action(knowledgeListAction);
+
+  knowledge
+    .command('show')
+    .description('Show validated selectors for a URL')
+    .option('--url <url>', 'URL to show selectors for')
+    .action(async (opts: Record<string, unknown>) => {
+      await knowledgeShowAction(opts);
+    });
+
+  knowledge
+    .command('reset')
+    .description('Reset knowledge entries')
+    .option('--url <url>', 'Exact URL to reset')
+    .option('--path <path>', 'Path to reset')
+    .option('--deep', 'Include sub-paths when using --path')
+    .action(async (opts: Record<string, unknown>) => {
+      await knowledgeResetAction(opts);
+    });
+
+  return knowledge;
+}

--- a/packages/core/src/cli/commands/setup-add.ts
+++ b/packages/core/src/cli/commands/setup-add.ts
@@ -1,0 +1,206 @@
+import { resolve } from 'node:path';
+
+import { confirm, input, password, select } from '@inquirer/prompts';
+
+import { AiServiceClient } from '../../ai/AiServiceClient.js';
+import { PythonServerManager } from '../../ai/PythonServerManager.js';
+import { ActionExecutor } from '../../browser/ActionExecutor.js';
+import { BrowserManager } from '../../browser/BrowserManager.js';
+import { HtmlExtractor } from '../../browser/HtmlExtractor.js';
+import { ConfigWriter } from '../../config/ConfigWriter.js';
+import type { AuthFlow, LoginSelectors } from '../../config/ProjectConfig.js';
+import { ExplorationAgent } from '../../agents/ExplorationAgent.js';
+import { createAgentContext } from '../../domain/AgentContext.js';
+import type { LearnedSelector } from '../../domain/ExplorationReport.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+// ── Login selector extraction ─────────────────────────────────────────
+
+function extractLoginSelectors(learnedSelectors: LearnedSelector[]): LoginSelectors | undefined {
+  let emailSelector: string | undefined;
+  let passwordSelector: string | undefined;
+  let submitSelector: string | undefined;
+
+  for (const sel of learnedSelectors) {
+    const desc = sel.description.toLowerCase();
+    const action = sel.action.toLowerCase();
+
+    if (action === 'fill' && !emailSelector && (desc.includes('email') || desc.includes('user'))) {
+      emailSelector = sel.selector;
+    } else if (action === 'fill' && !passwordSelector && desc.includes('password')) {
+      passwordSelector = sel.selector;
+    } else if (action === 'click' && !submitSelector && (desc.includes('submit') || desc.includes('login') || desc.includes('sign'))) {
+      submitSelector = sel.selector;
+    }
+  }
+
+  if (emailSelector && passwordSelector && submitSelector) {
+    return { email: emailSelector, password: passwordSelector, submit: submitSelector };
+  }
+  return undefined;
+}
+
+// ── Mini Session A: explore login form ────────────────────────────────
+
+async function exploreLoginForm(
+  baseUrl: string,
+  email: string,
+  passwordValue: string,
+): Promise<LoginSelectors | undefined> {
+  const pythonServer = new PythonServerManager();
+  const browser = new BrowserManager({ headless: false, slowMo: 150 });
+
+  try {
+    ui.info('Starting AI Service...');
+    await pythonServer.start();
+
+    ui.info('Launching browser...');
+    const page = await browser.launch();
+    const aiClient = new AiServiceClient(pythonServer.baseUrl);
+    const htmlExtractor = new HtmlExtractor();
+    const actionExecutor = new ActionExecutor(page);
+    const explorationAgent = new ExplorationAgent(aiClient, htmlExtractor, actionExecutor, page);
+
+    const objective =
+      `Navigate to ${baseUrl}, find the login form, ` +
+      `fill the email/username field with "${email}" ` +
+      `and the password field with the password, ` +
+      `then click the submit/login button.`;
+
+    const context = createAgentContext({
+      rawInput: `Login to ${baseUrl} as ${email}`,
+      url: baseUrl,
+      objective,
+      testName: 'setup-login-verification',
+      parameters: { password: passwordValue },
+      maxIterations: 10,
+    });
+
+    ui.info('Exploring login form...');
+    const report = await explorationAgent.run(context);
+
+    if (report.completed) {
+      ui.success(`Login exploration completed in ${String(report.totalRounds)} rounds`);
+      const selectors = extractLoginSelectors(report.learnedSelectors);
+      if (selectors) {
+        ui.success('Login selectors discovered');
+        ui.listItem('Email', selectors.email);
+        ui.listItem('Password', selectors.password);
+        ui.listItem('Submit', selectors.submit);
+      }
+      return selectors;
+    }
+
+    ui.warn('Login exploration did not complete — selectors not discovered');
+    return undefined;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ui.warn(`AI exploration failed: ${message}`);
+    return undefined;
+  } finally {
+    await browser.close();
+    await pythonServer.stop();
+  }
+}
+
+// ── Main action ───────────────────────────────────────────────────────
+
+export async function setupAddAction(): Promise<void> {
+  ui.header('ppia setup — Add new setup');
+
+  // 1. Collect environment data
+  const envName = await input({ message: 'Environment name:' });
+  const baseUrl = await input({ message: 'Base URL:' });
+
+  // 2. Collect user data
+  const userName = await input({ message: 'Username:' });
+  const userEmail = await input({ message: 'Email (optional):' });
+
+  const authFlow = await select<AuthFlow>({
+    message: 'Auth flow:',
+    choices: [
+      { name: 'Login form', value: 'login_form' as const },
+      { name: 'Cookie injection', value: 'cookie_injection' as const },
+    ],
+  });
+
+  const userRole = await input({ message: 'Role (optional):' });
+
+  // 3. Password handling
+  let passwordForYaml = '';
+  let resolvedPassword = '';
+
+  if (authFlow === 'login_form') {
+    const storageMode = await select({
+      message: 'How to store the password?',
+      choices: [
+        { name: 'Environment variable (recommended)', value: 'env_var' as const },
+        { name: 'Direct value', value: 'direct' as const },
+      ],
+    });
+
+    if (storageMode === 'env_var') {
+      const envVarName = await input({
+        message: 'Environment variable name:',
+        default: `${userName.toUpperCase()}_PASSWORD`,
+      });
+      passwordForYaml = `\${${envVarName}}`;
+
+      const envValue = process.env[envVarName];
+      if (envValue) {
+        resolvedPassword = envValue;
+        ui.info(`Using value from $${envVarName}`);
+      } else {
+        resolvedPassword = await password({
+          message: `Value for ${envVarName} (for verification, not stored):`,
+        });
+      }
+    } else {
+      resolvedPassword = await password({ message: 'Password:' });
+      passwordForYaml = resolvedPassword;
+    }
+  }
+
+  // 4. Optional: explore login form with AI
+  let loginSelectors: LoginSelectors | undefined;
+
+  if (authFlow === 'login_form') {
+    const shouldExplore = await confirm({
+      message: 'Explore login form with AI? (discovers selectors, requires Python AI Service)',
+      default: false,
+    });
+
+    if (shouldExplore && userEmail) {
+      loginSelectors = await exploreLoginForm(baseUrl, userEmail, resolvedPassword);
+    } else if (shouldExplore && !userEmail) {
+      ui.warn('Email is required for login exploration — skipping');
+    }
+  }
+
+  // 5. Write to ppia.yaml
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+  const writer = new ConfigWriter(configPath);
+
+  await writer.ensureProjectName(envName);
+  await writer.addEnvironment(envName, baseUrl);
+  await writer.addUser(userName, {
+    email: userEmail || undefined,
+    password: passwordForYaml || undefined,
+    role: userRole || undefined,
+    authFlow,
+    loginSelectors,
+  });
+  await writer.addSetupCombination(envName, userName);
+
+  // 6. Summary
+  ui.blank();
+  ui.success(`Setup written to ${configPath}`);
+  ui.listItem('Environment', `${envName} → ${baseUrl}`);
+  ui.listItem('User', `${userName} (${authFlow})`);
+  if (loginSelectors) {
+    ui.listItem('Selectors', 'custom (AI-discovered)');
+  } else {
+    ui.listItem('Selectors', 'default (verify with "ppia setup test")');
+  }
+  ui.blank();
+}

--- a/packages/core/src/cli/commands/setup-list.ts
+++ b/packages/core/src/cli/commands/setup-list.ts
@@ -1,0 +1,59 @@
+import { resolve } from 'node:path';
+
+import { loadProjectConfig, ProjectConfigError } from '../../config/ProjectConfig.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+export async function setupListAction(): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  try {
+    const config = await loadProjectConfig(configPath);
+
+    ui.header(`${config.projectName} — Setups`);
+
+    if (config.environments.length === 0 && config.users.length === 0) {
+      ui.warn('No setups configured. Run "ppia setup add" to create one.');
+      return;
+    }
+
+    if (config.environments.length > 0) {
+      ui.subheader('Environments');
+      for (const env of config.environments) {
+        const extra = env.cookies ? ` (cookies: ${env.cookies})` : '';
+        ui.listItem(env.name, `${env.baseUrl}${extra}`);
+      }
+    }
+
+    if (config.users.length > 0) {
+      ui.subheader('Users');
+      for (const user of config.users) {
+        const details: string[] = [user.authFlow];
+        if (user.role) {
+          details.push(user.role);
+        }
+        if (user.email) {
+          details.push(user.email);
+        }
+        if (user.loginSelectors) {
+          details.push('selectors: custom');
+        }
+        ui.listItem(user.name, details.join(' | '));
+      }
+    }
+
+    if (config.setupCombinations.length > 0) {
+      ui.subheader('Combinations');
+      for (const combo of config.setupCombinations) {
+        ui.listItem(combo.environment, combo.users.join(', '));
+      }
+    }
+
+    ui.blank();
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(err.message);
+    } else {
+      throw err;
+    }
+  }
+}

--- a/packages/core/src/cli/commands/setup-remove.ts
+++ b/packages/core/src/cli/commands/setup-remove.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path';
+
+import { ConfigWriter } from '../../config/ConfigWriter.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+export async function setupRemoveAction(envName: string, userName: string): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+  const writer = new ConfigWriter(configPath);
+
+  ui.header('ppia setup — Remove');
+
+  const removed = await writer.removeSetup(envName, userName);
+
+  if (removed) {
+    ui.success(`Setup removed: ${envName} / ${userName}`);
+  } else {
+    ui.warn(`Setup not found: ${envName} / ${userName}`);
+  }
+}

--- a/packages/core/src/cli/commands/setup-test.ts
+++ b/packages/core/src/cli/commands/setup-test.ts
@@ -1,0 +1,48 @@
+import { resolve } from 'node:path';
+
+import { ActionExecutor } from '../../browser/ActionExecutor.js';
+import { BrowserManager } from '../../browser/BrowserManager.js';
+import { loadProjectConfig, ProjectConfigError } from '../../config/ProjectConfig.js';
+import { SetupManager } from '../../config/SetupManager.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+export async function setupTestAction(envName: string, userName: string): Promise<void> {
+  const configPath = resolve(process.cwd(), 'ppia.yaml');
+
+  ui.header('ppia setup — Test');
+  ui.info(`Testing setup: ${envName} / ${userName}`);
+
+  let config;
+  try {
+    config = await loadProjectConfig(configPath);
+  } catch (err) {
+    if (err instanceof ProjectConfigError) {
+      ui.error(err.message);
+      return;
+    }
+    throw err;
+  }
+
+  const browser = new BrowserManager({ headless: false, slowMo: 100 });
+
+  try {
+    ui.info('Launching browser...');
+    const page = await browser.launch();
+    const actionExecutor = new ActionExecutor(page);
+    const setupManager = new SetupManager(config, actionExecutor, page);
+
+    const setup = setupManager.loadSetup(envName, userName);
+    ui.info(`Authenticating as "${userName}" on "${envName}" (${setup.environment.baseUrl})...`);
+
+    await setupManager.authenticate(setup);
+
+    ui.success('Authentication completed successfully');
+    ui.info(`Final URL: ${page.url()}`);
+    ui.blank();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    ui.error(`Authentication failed: ${message}`);
+  } finally {
+    await browser.close();
+  }
+}

--- a/packages/core/src/cli/commands/setup.ts
+++ b/packages/core/src/cli/commands/setup.ts
@@ -1,0 +1,37 @@
+import { Command } from 'commander';
+
+import { setupAddAction } from './setup-add.js';
+import { setupListAction } from './setup-list.js';
+import { setupRemoveAction } from './setup-remove.js';
+import { setupTestAction } from './setup-test.js';
+
+export function createSetupCommand(): Command {
+  const setup = new Command('setup')
+    .description('Manage authentication setups in ppia.yaml');
+
+  setup
+    .command('add')
+    .description('Add a new setup interactively')
+    .action(setupAddAction);
+
+  setup
+    .command('list')
+    .description('List available setups from ppia.yaml')
+    .action(setupListAction);
+
+  setup
+    .command('test')
+    .description('Test a setup with a real browser')
+    .argument('<env>', 'Environment name')
+    .argument('<user>', 'User name')
+    .action(setupTestAction);
+
+  setup
+    .command('remove')
+    .description('Remove a setup from ppia.yaml')
+    .argument('<env>', 'Environment name')
+    .argument('<user>', 'User name')
+    .action(setupRemoveAction);
+
+  return setup;
+}

--- a/packages/core/src/cli/commands/suite-cmd.ts
+++ b/packages/core/src/cli/commands/suite-cmd.ts
@@ -1,0 +1,148 @@
+import { resolve } from 'node:path';
+
+import { Command } from 'commander';
+
+import { SuiteManager } from '../../suite/SuiteManager.js';
+import * as ui from '../ui/ProgressDisplay.js';
+
+function createManager(): SuiteManager {
+  return new SuiteManager(resolve(process.cwd()));
+}
+
+function parseDuration(value: string): number | undefined {
+  const match = /^(\d+)d$/.exec(value);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  return parseInt(match[1], 10);
+}
+
+async function suiteListAction(): Promise<void> {
+  const manager = createManager();
+  const entries = await manager.list();
+
+  if (entries.length === 0) {
+    ui.info('No tests generated yet. Run "ppia generate" to create your first test.');
+    return;
+  }
+
+  ui.header('Generated Tests');
+  for (const entry of entries) {
+    const date = entry.createdAt.split('T')[0] ?? entry.createdAt;
+    ui.listItem(
+      entry.testName,
+      `v${String(entry.version)} | ${date} | ${entry.metrics.modelStrong} | ${ui.formatTokens(entry.metrics.totalTokensUsed)}`,
+    );
+  }
+  ui.blank();
+}
+
+async function suiteShowAction(testName: string): Promise<void> {
+  const manager = createManager();
+  const entry = await manager.getById(testName);
+
+  if (!entry) {
+    ui.error(`Test "${testName}" not found in suite.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  ui.header(`Test: ${entry.testName}`);
+  ui.listItem('Description', entry.description);
+  ui.listItem('URL', entry.url);
+  ui.listItem('Version', String(entry.version));
+  ui.listItem('Created', entry.createdAt);
+  if (entry.testFilePath) {
+    ui.listItem('File', entry.testFilePath);
+  }
+
+  ui.subheader('Metrics');
+  ui.listItem('Tokens', ui.formatTokens(entry.metrics.totalTokensUsed));
+  ui.listItem('Cost', ui.formatCost(entry.metrics.totalCost));
+  ui.listItem('Models', `${entry.metrics.modelFast} / ${entry.metrics.modelStrong}`);
+  ui.listItem('Exploration', `${String(entry.metrics.explorationRounds)} rounds`);
+  ui.listItem('Generation', `${String(entry.metrics.generationAttempts)} attempt${entry.metrics.generationAttempts > 1 ? 's' : ''}`);
+
+  ui.subheader('Test Code');
+  console.log(entry.testCode);
+
+  ui.blank();
+}
+
+async function suiteVersionsAction(testName: string): Promise<void> {
+  const manager = createManager();
+  const versions = await manager.getVersions(testName);
+
+  if (versions.length === 0) {
+    ui.error(`No versions found for "${testName}".`);
+    process.exitCode = 1;
+    return;
+  }
+
+  ui.header(`Versions: ${testName}`);
+  for (const entry of versions) {
+    const date = entry.createdAt.split('T')[0] ?? entry.createdAt;
+    ui.listItem(
+      `v${String(entry.version)}`,
+      `${date} | ${ui.formatTokens(entry.metrics.totalTokensUsed)} | ${ui.formatCost(entry.metrics.totalCost)}`,
+    );
+  }
+  ui.blank();
+}
+
+async function suiteCleanAction(opts: Record<string, unknown>): Promise<void> {
+  const olderThan = typeof opts.olderThan === 'string' ? opts.olderThan : undefined;
+  if (!olderThan) {
+    ui.error('--older-than is required. Usage: ppia suite clean --older-than 30d');
+    process.exitCode = 1;
+    return;
+  }
+
+  const days = parseDuration(olderThan);
+  if (days === undefined) {
+    ui.error(`Invalid duration "${olderThan}". Use format: <number>d (e.g., 30d)`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const manager = createManager();
+  const removed = await manager.clean(days);
+
+  if (removed === 0) {
+    ui.info('No tests older than the specified threshold.');
+  } else {
+    ui.success(`Removed ${String(removed)} test${removed > 1 ? 's' : ''}.`);
+  }
+}
+
+export function createSuiteCommand(): Command {
+  const suite = new Command('suite')
+    .description('View and manage generated test history');
+
+  suite
+    .command('list')
+    .description('List all generated tests')
+    .action(suiteListAction);
+
+  suite
+    .command('show')
+    .description('Show details of a generated test')
+    .argument('<testName>', 'Name of the test to show')
+    .action(suiteShowAction);
+
+  suite
+    .command('versions')
+    .description('Show version history of a test')
+    .argument('<testName>', 'Name of the test')
+    .action(suiteVersionsAction);
+
+  suite
+    .command('clean')
+    .description('Remove old tests from the suite')
+    .option('--older-than <duration>', 'Remove tests older than duration (e.g., 30d)')
+    .action(async (opts: Record<string, unknown>) => {
+      await suiteCleanAction(opts);
+    });
+
+  return suite;
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 
 import { createConfigCommand } from './commands/config-cmd.js';
 import { registerGenerateCommand } from './commands/generate.js';
+import { registerInitCommand } from './commands/init.js';
 import { createKnowledgeCommand } from './commands/knowledge.js';
 import { createSetupCommand } from './commands/setup.js';
 import { createSuiteCommand } from './commands/suite-cmd.js';
@@ -15,6 +16,7 @@ program
   .description('AI-powered test generation for Playwright')
   .version('0.1.0');
 
+registerInitCommand(program);
 registerGenerateCommand(program);
 program.addCommand(createSetupCommand());
 program.addCommand(createKnowledgeCommand());

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,3 +1,20 @@
 #!/usr/bin/env node
 
-// CLI entry point: ppia command.
+import { Command } from 'commander';
+
+import { createSetupCommand } from './commands/setup.js';
+
+const program = new Command();
+
+program
+  .name('ppia')
+  .description('AI-powered test generation for Playwright')
+  .version('0.1.0');
+
+program.addCommand(createSetupCommand());
+
+program.parseAsync().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${message}`);
+  process.exit(1);
+});

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 
+import { registerGenerateCommand } from './commands/generate.js';
 import { createSetupCommand } from './commands/setup.js';
 
 const program = new Command();
@@ -11,6 +12,7 @@ program
   .description('AI-powered test generation for Playwright')
   .version('0.1.0');
 
+registerGenerateCommand(program);
 program.addCommand(createSetupCommand());
 
 program.parseAsync().catch((err: unknown) => {

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -2,8 +2,11 @@
 
 import { Command } from 'commander';
 
+import { createConfigCommand } from './commands/config-cmd.js';
 import { registerGenerateCommand } from './commands/generate.js';
+import { createKnowledgeCommand } from './commands/knowledge.js';
 import { createSetupCommand } from './commands/setup.js';
+import { createSuiteCommand } from './commands/suite-cmd.js';
 
 const program = new Command();
 
@@ -14,6 +17,9 @@ program
 
 registerGenerateCommand(program);
 program.addCommand(createSetupCommand());
+program.addCommand(createKnowledgeCommand());
+program.addCommand(createSuiteCommand());
+program.addCommand(createConfigCommand());
 
 program.parseAsync().catch((err: unknown) => {
   const message = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/cli/ui/ProgressDisplay.ts
+++ b/packages/core/src/cli/ui/ProgressDisplay.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
 
+// ── Basic UI ──────────────────────────────────────────────────────────
+
 export function header(title: string): void {
   console.log();
   console.log(chalk.bold(`\u2726 ${title}`));
@@ -33,4 +35,76 @@ export function listItem(label: string, value: string): void {
 
 export function blank(): void {
   console.log();
+}
+
+// ── Cost estimation ───────────────────────────────────────────────────
+
+// Blended rate per token (approximate input/output average) in USD.
+const MODEL_RATES: Record<string, number> = {
+  'gpt-4o-mini': 0.3e-6,
+  'gpt-4o': 5.0e-6,
+  'claude-haiku-4-5': 2.0e-6,
+  'claude-sonnet-4-5': 6.0e-6,
+  'claude-sonnet-4-6': 6.0e-6,
+  'claude-opus-4-6': 30.0e-6,
+};
+
+const DEFAULT_RATE = 3.0e-6;
+
+export function estimateCost(model: string, tokens: number): number {
+  const rate = MODEL_RATES[model] ?? DEFAULT_RATE;
+  return tokens * rate;
+}
+
+export function formatCost(cost: number): string {
+  if (cost < 0.01) {
+    return `~$${cost.toFixed(5)}`;
+  }
+  return `~$${cost.toFixed(3)}`;
+}
+
+export function formatTokens(tokens: number): string {
+  if (tokens >= 1000) {
+    return `${(tokens / 1000).toFixed(1)}k tok`;
+  }
+  return `${String(tokens)} tok`;
+}
+
+// ── Generate progress ─────────────────────────────────────────────────
+
+export function phaseRow(phase: string, detail: string, model: string, tokens: number): void {
+  const cost = estimateCost(model, tokens);
+  console.log(
+    `  ${chalk.cyan('◉')} ` +
+    `${phase.padEnd(15)} ` +
+    `${detail.padEnd(16)} ` +
+    `${chalk.dim(model.padEnd(18))} ` +
+    `${formatTokens(tokens).padStart(10)}   ` +
+    chalk.dim(formatCost(cost)),
+  );
+}
+
+export function separator(): void {
+  console.log(chalk.dim(`  ${'─'.repeat(50)}`));
+}
+
+export interface GenerateSummary {
+  totalTokens: number;
+  totalCost: number;
+  explorationRounds: number;
+  generationAttempts: number;
+  testPath: string;
+}
+
+export function generateSummary(summary: GenerateSummary): void {
+  blank();
+  success(
+    `Test generated  |  ${formatTokens(summary.totalTokens)}  |  ${formatCost(summary.totalCost)}`,
+  );
+  listItem('Exploration', `${String(summary.explorationRounds)} rounds`);
+  listItem('Generation', `${String(summary.generationAttempts)} attempt${summary.generationAttempts > 1 ? 's' : ''}`);
+  if (summary.testPath) {
+    listItem('Output', summary.testPath);
+  }
+  blank();
 }

--- a/packages/core/src/cli/ui/ProgressDisplay.ts
+++ b/packages/core/src/cli/ui/ProgressDisplay.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk';
+
+export function header(title: string): void {
+  console.log();
+  console.log(chalk.bold(`\u2726 ${title}`));
+  console.log(chalk.dim(`  ${'─'.repeat(50)}`));
+}
+
+export function subheader(title: string): void {
+  console.log();
+  console.log(chalk.bold(`  ${title}`));
+}
+
+export function info(message: string): void {
+  console.log(`  ${chalk.cyan('ℹ')} ${message}`);
+}
+
+export function success(message: string): void {
+  console.log(`  ${chalk.green('✓')} ${message}`);
+}
+
+export function error(message: string): void {
+  console.error(`  ${chalk.red('✗')} ${message}`);
+}
+
+export function warn(message: string): void {
+  console.log(`  ${chalk.yellow('!')} ${message}`);
+}
+
+export function listItem(label: string, value: string): void {
+  console.log(`    ${chalk.cyan(label)}  ${chalk.dim(value)}`);
+}
+
+export function blank(): void {
+  console.log();
+}

--- a/packages/core/src/config/ConfigWriter.ts
+++ b/packages/core/src/config/ConfigWriter.ts
@@ -1,0 +1,221 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+import { parse, stringify } from 'yaml';
+
+import type { AuthFlow, LoginSelectors } from './ProjectConfig.js';
+
+// ── Raw YAML structure (snake_case) ───────────────────────────────────
+
+interface RawEnvironment {
+  name: string;
+  base_url: string;
+  cookies?: string;
+}
+
+interface RawLoginSelectors {
+  email: string;
+  password: string;
+  submit: string;
+}
+
+interface RawUser {
+  name: string;
+  email?: string;
+  password?: string;
+  role?: string;
+  auth_flow: string;
+  login_selectors?: RawLoginSelectors;
+}
+
+interface RawCombination {
+  environment: string;
+  users: string[];
+}
+
+interface RawYamlConfig {
+  project?: { name?: string; description?: string };
+  ai_service?: Record<string, unknown>;
+  environments?: RawEnvironment[];
+  users?: RawUser[];
+  setup_combinations?: RawCombination[];
+  output?: Record<string, unknown>;
+}
+
+// ── Public types ──────────────────────────────────────────────────────
+
+export interface AddUserOptions {
+  email?: string;
+  password?: string;
+  role?: string;
+  authFlow: AuthFlow;
+  loginSelectors?: LoginSelectors;
+}
+
+// ── ConfigWriter ──────────────────────────────────────────────────────
+
+export class ConfigWriter {
+  constructor(private readonly filePath: string) {}
+
+  async read(): Promise<RawYamlConfig> {
+    try {
+      const content = await readFile(this.filePath, 'utf-8');
+      const parsed = parse(content) as RawYamlConfig | null;
+      return parsed ?? {};
+    } catch {
+      return {};
+    }
+  }
+
+  private async write(config: RawYamlConfig): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const content = stringify(config, { lineWidth: 120 });
+    await writeFile(this.filePath, content, 'utf-8');
+  }
+
+  async ensureProjectName(name: string): Promise<void> {
+    const config = await this.read();
+    if (!config.project) {
+      config.project = {};
+    }
+    if (!config.project.name) {
+      config.project.name = name;
+    }
+    await this.write(config);
+  }
+
+  async addEnvironment(name: string, baseUrl: string, cookies?: string): Promise<void> {
+    const config = await this.read();
+    if (!config.environments) {
+      config.environments = [];
+    }
+
+    const existing = config.environments.find((e) => e.name === name);
+    if (existing) {
+      existing.base_url = baseUrl;
+      if (cookies) {
+        existing.cookies = cookies;
+      }
+    } else {
+      const entry: RawEnvironment = { name, base_url: baseUrl };
+      if (cookies) {
+        entry.cookies = cookies;
+      }
+      config.environments.push(entry);
+    }
+
+    await this.write(config);
+  }
+
+  async addUser(name: string, options: AddUserOptions): Promise<void> {
+    const config = await this.read();
+    if (!config.users) {
+      config.users = [];
+    }
+
+    const entry: RawUser = {
+      name,
+      auth_flow: options.authFlow,
+    };
+    if (options.email) {
+      entry.email = options.email;
+    }
+    if (options.password) {
+      entry.password = options.password;
+    }
+    if (options.role) {
+      entry.role = options.role;
+    }
+    if (options.loginSelectors) {
+      entry.login_selectors = {
+        email: options.loginSelectors.email,
+        password: options.loginSelectors.password,
+        submit: options.loginSelectors.submit,
+      };
+    }
+
+    const existingIndex = config.users.findIndex((u) => u.name === name);
+    if (existingIndex !== -1) {
+      config.users[existingIndex] = entry;
+    } else {
+      config.users.push(entry);
+    }
+
+    await this.write(config);
+  }
+
+  async addSetupCombination(envName: string, userName: string): Promise<void> {
+    const config = await this.read();
+    if (!config.setup_combinations) {
+      config.setup_combinations = [];
+    }
+
+    const existing = config.setup_combinations.find((c) => c.environment === envName);
+    if (existing) {
+      if (!existing.users.includes(userName)) {
+        existing.users.push(userName);
+      }
+    } else {
+      config.setup_combinations.push({
+        environment: envName,
+        users: [userName],
+      });
+    }
+
+    await this.write(config);
+  }
+
+  async removeSetup(envName: string, userName: string): Promise<boolean> {
+    const config = await this.read();
+    if (!config.setup_combinations) {
+      return false;
+    }
+
+    const combo = config.setup_combinations.find((c) => c.environment === envName);
+    if (!combo) {
+      return false;
+    }
+
+    const userIndex = combo.users.indexOf(userName);
+    if (userIndex === -1) {
+      return false;
+    }
+
+    combo.users.splice(userIndex, 1);
+
+    if (combo.users.length === 0) {
+      config.setup_combinations = config.setup_combinations.filter(
+        (c) => c.environment !== envName,
+      );
+    }
+
+    // Also remove the user definition if not used in any other combination
+    const userStillUsed = config.setup_combinations.some(
+      (c) => c.users.includes(userName),
+    );
+    if (!userStillUsed && config.users) {
+      config.users = config.users.filter((u) => u.name !== userName);
+    }
+
+    // Also remove the environment if no combinations reference it
+    const envStillUsed = config.setup_combinations.some(
+      (c) => c.environment === envName,
+    );
+    if (!envStillUsed && config.environments) {
+      config.environments = config.environments.filter((e) => e.name !== envName);
+    }
+
+    await this.write(config);
+    return true;
+  }
+
+  async hasEnvironment(name: string): Promise<boolean> {
+    const config = await this.read();
+    return config.environments?.some((e) => e.name === name) ?? false;
+  }
+
+  async hasUser(name: string): Promise<boolean> {
+    const config = await this.read();
+    return config.users?.some((u) => u.name === name) ?? false;
+  }
+}

--- a/packages/core/src/config/ProjectConfig.ts
+++ b/packages/core/src/config/ProjectConfig.ts
@@ -12,12 +12,19 @@ export interface EnvironmentConfig {
 
 export type AuthFlow = 'login_form' | 'cookie_injection';
 
+export interface LoginSelectors {
+  email: string;
+  password: string;
+  submit: string;
+}
+
 export interface UserConfig {
   name: string;
   email?: string;
   password?: string;
   role?: string;
   authFlow: AuthFlow;
+  loginSelectors?: LoginSelectors;
 }
 
 export interface SetupCombination {
@@ -56,6 +63,7 @@ interface RawUser {
   password?: unknown;
   role?: unknown;
   auth_flow?: unknown;
+  login_selectors?: unknown;
 }
 
 interface RawCombination {
@@ -110,6 +118,17 @@ function parseEnvironment(raw: RawEnvironment, index: number): EnvironmentConfig
   };
 }
 
+function parseLoginSelectors(raw: unknown): LoginSelectors | undefined {
+  if (!raw || typeof raw !== 'object') {
+    return undefined;
+  }
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.email !== 'string' || typeof obj.password !== 'string' || typeof obj.submit !== 'string') {
+    return undefined;
+  }
+  return { email: obj.email, password: obj.password, submit: obj.submit };
+}
+
 function parseUser(raw: RawUser, index: number): UserConfig {
   if (typeof raw.name !== 'string' || raw.name.length === 0) {
     throw new ProjectConfigError(
@@ -123,13 +142,18 @@ function parseUser(raw: RawUser, index: number): UserConfig {
       `users[${String(index)}].auth_flow`,
     );
   }
-  return {
+  const user: UserConfig = {
     name: raw.name,
     email: resolveOptionalString(raw.email),
     password: resolveOptionalString(raw.password),
     role: typeof raw.role === 'string' ? raw.role : undefined,
     authFlow: raw.auth_flow as AuthFlow,
   };
+  const loginSelectors = parseLoginSelectors(raw.login_selectors);
+  if (loginSelectors) {
+    user.loginSelectors = loginSelectors;
+  }
+  return user;
 }
 
 function parseCombination(

--- a/packages/core/src/config/ProjectConfig.ts
+++ b/packages/core/src/config/ProjectConfig.ts
@@ -32,8 +32,26 @@ export interface SetupCombination {
   users: string[];
 }
 
+export type AiProvider = 'openai' | 'anthropic';
+
+export interface AiModelConfig {
+  provider: AiProvider;
+  model: string;
+}
+
+export interface AiConfig {
+  exploration: AiModelConfig;
+  generation: AiModelConfig;
+}
+
+export const DEFAULT_AI_CONFIG: AiConfig = {
+  exploration: { provider: 'openai', model: 'gpt-4o-mini' },
+  generation: { provider: 'openai', model: 'gpt-4o' },
+};
+
 export interface ProjectConfig {
   projectName: string;
+  ai: AiConfig;
   environments: EnvironmentConfig[];
   users: UserConfig[];
   setupCombinations: SetupCombination[];
@@ -71,8 +89,19 @@ interface RawCombination {
   users?: unknown;
 }
 
+interface RawAiModelConfig {
+  provider?: unknown;
+  model?: unknown;
+}
+
+interface RawAiConfig {
+  exploration?: unknown;
+  generation?: unknown;
+}
+
 interface RawConfig {
   project?: { name?: unknown };
+  ai?: unknown;
   environments?: unknown[];
   users?: unknown[];
   setup_combinations?: unknown[];
@@ -188,6 +217,45 @@ function parseCombination(
   };
 }
 
+const VALID_AI_PROVIDERS: readonly AiProvider[] = ['openai', 'anthropic'];
+
+function parseAiModelConfig(
+  raw: unknown,
+  field: string,
+  fallback: AiModelConfig,
+): AiModelConfig {
+  if (!raw || typeof raw !== 'object') {
+    return fallback;
+  }
+  const obj = raw as RawAiModelConfig;
+  const provider = typeof obj.provider === 'string' && VALID_AI_PROVIDERS.includes(obj.provider as AiProvider)
+    ? (obj.provider as AiProvider)
+    : fallback.provider;
+  const model = typeof obj.model === 'string' && obj.model.length > 0
+    ? obj.model
+    : fallback.model;
+
+  if (typeof obj.provider === 'string' && !VALID_AI_PROVIDERS.includes(obj.provider as AiProvider)) {
+    throw new ProjectConfigError(
+      `ai.${field}.provider must be one of: ${VALID_AI_PROVIDERS.join(', ')}. Got: "${obj.provider}"`,
+      `ai.${field}.provider`,
+    );
+  }
+
+  return { provider, model };
+}
+
+function parseAiConfig(raw: unknown): AiConfig {
+  if (!raw || typeof raw !== 'object') {
+    return DEFAULT_AI_CONFIG;
+  }
+  const obj = raw as RawAiConfig;
+  return {
+    exploration: parseAiModelConfig(obj.exploration, 'exploration', DEFAULT_AI_CONFIG.exploration),
+    generation: parseAiModelConfig(obj.generation, 'generation', DEFAULT_AI_CONFIG.generation),
+  };
+}
+
 // ── Main ───────────────────────────────────────────────────────────────
 
 export async function loadProjectConfig(filePath: string): Promise<ProjectConfig> {
@@ -219,6 +287,8 @@ export async function loadProjectConfig(filePath: string): Promise<ProjectConfig
     );
   }
 
+  const ai = parseAiConfig(config.ai);
+
   const rawEnvironments = Array.isArray(config.environments) ? config.environments : [];
   const rawUsers = Array.isArray(config.users) ? config.users : [];
   const rawCombinations = Array.isArray(config.setup_combinations) ? config.setup_combinations : [];
@@ -239,6 +309,7 @@ export async function loadProjectConfig(filePath: string): Promise<ProjectConfig
 
   return {
     projectName,
+    ai,
     environments,
     users,
     setupCombinations,

--- a/packages/core/src/config/SetupManager.test.ts
+++ b/packages/core/src/config/SetupManager.test.ts
@@ -6,6 +6,7 @@ vi.mock('node:fs/promises', () => ({
 
 import { readFile } from 'node:fs/promises';
 
+import { DEFAULT_AI_CONFIG } from './ProjectConfig.js';
 import type { ProjectConfig } from './ProjectConfig.js';
 import { SetupManager } from './SetupManager.js';
 
@@ -14,6 +15,7 @@ const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
 function createConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
   return {
     projectName: 'test-app',
+    ai: DEFAULT_AI_CONFIG,
     environments: [
       { name: 'staging', baseUrl: 'https://staging.example.com' },
       { name: 'production', baseUrl: 'https://prod.example.com', cookies: '/path/to/cookies.json' },

--- a/packages/core/src/config/SetupManager.ts
+++ b/packages/core/src/config/SetupManager.ts
@@ -58,6 +58,12 @@ export class SetupManager {
   }
 
   private async authenticateViaLoginForm(setup: ResolvedSetup): Promise<void> {
+    const selectors = setup.user.loginSelectors ?? {
+      email: 'getByLabel("Email")',
+      password: 'getByLabel("Password")',
+      submit: 'getByRole("button", { name: "Submit" })',
+    };
+
     await this.actionExecutor.execute({
       action: 'navigate',
       target: setup.environment.baseUrl,
@@ -65,17 +71,17 @@ export class SetupManager {
     });
     await this.actionExecutor.execute({
       action: 'fill',
-      target: 'getByLabel("Email")',
+      target: selectors.email,
       value: setup.user.email ?? '',
     });
     await this.actionExecutor.execute({
       action: 'fill',
-      target: 'getByLabel("Password")',
+      target: selectors.password,
       value: setup.user.password ?? '',
     });
     await this.actionExecutor.execute({
       action: 'click',
-      target: 'getByRole("button", { name: "Submit" })',
+      target: selectors.submit,
       value: null,
     });
   }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -2,9 +2,12 @@ export { loadProjectConfig, ProjectConfigError, resolveEnvVars } from './Project
 export type {
   AuthFlow,
   EnvironmentConfig,
+  LoginSelectors,
   ProjectConfig,
   SetupCombination,
   UserConfig,
 } from './ProjectConfig.js';
+export { ConfigWriter } from './ConfigWriter.js';
+export type { AddUserOptions } from './ConfigWriter.js';
 export { SetupManager } from './SetupManager.js';
 export type { ResolvedSetup } from './SetupManager.js';

--- a/packages/core/src/suite/KnowledgeBase.test.ts
+++ b/packages/core/src/suite/KnowledgeBase.test.ts
@@ -1,0 +1,198 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+import type { KnowledgeEntry } from './KnowledgeEntry.js';
+import { KnowledgeBase } from './KnowledgeBase.js';
+
+const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
+const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
+
+function getWrittenData(): KnowledgeEntry[] {
+  const call = mockWriteFile.mock.calls[0] as string[];
+  return JSON.parse(call[1] as string) as KnowledgeEntry[];
+}
+
+function createKnowledgeEntry(overrides: Partial<KnowledgeEntry> = {}): KnowledgeEntry {
+  return {
+    url: 'https://example.com/login',
+    elementDescription: 'email input',
+    reliableSelector: 'getByLabel("Email")',
+    problematicSelectors: ['#email-input'],
+    learnedFrom: 'login-test',
+    learnedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('KnowledgeBase', () => {
+  const baseDir = '/project';
+  let kb: KnowledgeBase;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    kb = new KnowledgeBase(baseDir);
+  });
+
+  describe('getByUrl', () => {
+    it('returns entries matching the given URL', async () => {
+      const entry1 = createKnowledgeEntry();
+      const entry2 = createKnowledgeEntry({
+        url: 'https://example.com/login',
+        elementDescription: 'password input',
+        reliableSelector: 'getByLabel("Password")',
+      });
+      const entry3 = createKnowledgeEntry({ url: 'https://example.com/dashboard' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([entry1, entry2, entry3]));
+
+      const result = await kb.getByUrl('https://example.com/login');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.elementDescription).toBe('email input');
+      expect(result[1]?.elementDescription).toBe('password input');
+    });
+
+    it('returns empty array when no entries exist', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await kb.getByUrl('https://example.com/login');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('update', () => {
+    it('adds new entries without removing existing ones', async () => {
+      const existing = createKnowledgeEntry();
+      const newEntry = createKnowledgeEntry({
+        url: 'https://example.com/dashboard',
+        elementDescription: 'nav menu',
+        reliableSelector: 'getByRole("navigation")',
+      });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([existing]));
+
+      await kb.update('https://example.com/dashboard', [newEntry]);
+
+      const written = getWrittenData();
+      expect(written).toHaveLength(2);
+      expect(written[0]).toEqual(existing);
+      expect(written[1]).toEqual(newEntry);
+    });
+
+    it('updates existing entries with matching url + elementDescription', async () => {
+      const existing = createKnowledgeEntry({ reliableSelector: 'old-selector' });
+      const updated = createKnowledgeEntry({ reliableSelector: 'new-selector' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([existing]));
+
+      await kb.update('https://example.com/login', [updated]);
+
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.reliableSelector).toBe('new-selector');
+    });
+
+    it('creates the file when it does not exist', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+      const entry = createKnowledgeEntry();
+
+      await kb.update('https://example.com/login', [entry]);
+
+      expect(mockMkdir).toHaveBeenCalled();
+      expect(mockWriteFile).toHaveBeenCalled();
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all entries when called without options', async () => {
+      const entries = [createKnowledgeEntry(), createKnowledgeEntry({ url: 'https://other.com' })];
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(entries));
+
+      const count = await kb.reset();
+
+      expect(count).toBe(2);
+      const written = getWrittenData();
+      expect(written).toEqual([]);
+    });
+
+    it('removes entries for an exact URL', async () => {
+      const keep = createKnowledgeEntry({ url: 'https://other.com' });
+      const remove = createKnowledgeEntry({ url: 'https://example.com/login' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep, remove]));
+
+      const count = await kb.reset({ url: 'https://example.com/login' });
+
+      expect(count).toBe(1);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://other.com');
+    });
+
+    it('removes entries matching an exact path', async () => {
+      const keep = createKnowledgeEntry({ url: 'https://example.com/dashboard' });
+      const remove = createKnowledgeEntry({ url: 'https://example.com/admin' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep, remove]));
+
+      const count = await kb.reset({ path: '/admin' });
+
+      expect(count).toBe(1);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://example.com/dashboard');
+    });
+
+    it('removes entries matching path and sub-paths with deep option', async () => {
+      const keep = createKnowledgeEntry({ url: 'https://example.com/dashboard' });
+      const remove1 = createKnowledgeEntry({ url: 'https://example.com/admin' });
+      const remove2 = createKnowledgeEntry({ url: 'https://example.com/admin/users' });
+      const remove3 = createKnowledgeEntry({ url: 'https://example.com/admin/settings' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep, remove1, remove2, remove3]));
+
+      const count = await kb.reset({ path: '/admin', deep: true });
+
+      expect(count).toBe(3);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://example.com/dashboard');
+    });
+
+    it('does not remove sub-paths when deep is false', async () => {
+      const keep1 = createKnowledgeEntry({ url: 'https://example.com/admin/users' });
+      const remove = createKnowledgeEntry({ url: 'https://example.com/admin' });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([keep1, remove]));
+
+      const count = await kb.reset({ path: '/admin' });
+
+      expect(count).toBe(1);
+      const written = getWrittenData();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.url).toBe('https://example.com/admin/users');
+    });
+
+    it('returns 0 when there are no entries to clear', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const count = await kb.reset();
+
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('getAll', () => {
+    it('returns all entries', async () => {
+      const entries = [createKnowledgeEntry(), createKnowledgeEntry({ url: 'https://other.com' })];
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(entries));
+
+      const result = await kb.getAll();
+
+      expect(result).toHaveLength(2);
+    });
+  });
+});

--- a/packages/core/src/suite/KnowledgeBase.ts
+++ b/packages/core/src/suite/KnowledgeBase.ts
@@ -1,0 +1,102 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { join } from 'node:path';
+
+import type { KnowledgeEntry, ResetOptions } from './KnowledgeEntry.js';
+
+export class KnowledgeBase {
+  private readonly filePath: string;
+
+  constructor(baseDir: string) {
+    this.filePath = join(baseDir, '.ppia', 'knowledge.json');
+  }
+
+  async getByUrl(url: string): Promise<KnowledgeEntry[]> {
+    const all = await this.readAll();
+    return all.filter((e) => e.url === url);
+  }
+
+  async update(url: string, entries: KnowledgeEntry[]): Promise<void> {
+    const all = await this.readAll();
+
+    for (const incoming of entries) {
+      const idx = all.findIndex(
+        (e) => e.url === incoming.url && e.elementDescription === incoming.elementDescription,
+      );
+      if (idx >= 0) {
+        all[idx] = incoming;
+      } else {
+        all.push(incoming);
+      }
+    }
+
+    await this.writeAll(all);
+  }
+
+  async reset(options?: ResetOptions): Promise<number> {
+    if (!options?.url && !options?.path) {
+      const all = await this.readAll();
+      const count = all.length;
+      await this.writeAll([]);
+      return count;
+    }
+
+    const all = await this.readAll();
+    const before = all.length;
+
+    let filtered: KnowledgeEntry[];
+
+    if (options.url) {
+      filtered = all.filter((e) => e.url !== options.url);
+    } else if (options.path) {
+      const targetPath = options.path;
+      filtered = all.filter((e) => !matchesPath(e.url, targetPath, options.deep ?? false));
+    } else {
+      filtered = all;
+    }
+
+    await this.writeAll(filtered);
+    return before - filtered.length;
+  }
+
+  async getAll(): Promise<KnowledgeEntry[]> {
+    return this.readAll();
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────
+
+  private async readAll(): Promise<KnowledgeEntry[]> {
+    try {
+      const raw = await readFile(this.filePath, 'utf-8');
+      return JSON.parse(raw) as KnowledgeEntry[];
+    } catch {
+      return [];
+    }
+  }
+
+  private async writeAll(entries: KnowledgeEntry[]): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    await writeFile(this.filePath, JSON.stringify(entries, null, 2), 'utf-8');
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function matchesPath(entryUrl: string, path: string, deep: boolean): boolean {
+  let urlPath: string;
+  try {
+    urlPath = new URL(entryUrl).pathname;
+  } catch {
+    return false;
+  }
+
+  // Normalize: remove trailing slash for comparison (unless root "/")
+  const normalizedUrlPath = urlPath.length > 1 ? urlPath.replace(/\/$/, '') : urlPath;
+  const normalizedTarget = path.length > 1 ? path.replace(/\/$/, '') : path;
+
+  if (deep) {
+    return normalizedUrlPath === normalizedTarget || normalizedUrlPath.startsWith(`${normalizedTarget}/`);
+  }
+
+  return normalizedUrlPath === normalizedTarget;
+}

--- a/packages/core/src/suite/KnowledgeEntry.ts
+++ b/packages/core/src/suite/KnowledgeEntry.ts
@@ -1,0 +1,14 @@
+export interface KnowledgeEntry {
+  url: string;
+  elementDescription: string;
+  reliableSelector: string;
+  problematicSelectors: string[];
+  learnedFrom: string;
+  learnedAt: string;
+}
+
+export interface ResetOptions {
+  url?: string;
+  path?: string;
+  deep?: boolean;
+}

--- a/packages/core/src/suite/SuiteEntry.ts
+++ b/packages/core/src/suite/SuiteEntry.ts
@@ -1,0 +1,28 @@
+export interface SuiteEntryMetrics {
+  totalTokensUsed: number;
+  totalCost: number;
+  modelFast: string;
+  modelStrong: string;
+  explorationRounds: number;
+  generationAttempts: number;
+  timestamp: string;
+}
+
+export interface SuiteEntryArtifacts {
+  pomMd: string;
+  gherkinMd: string;
+  cucumberMd: string;
+}
+
+export interface SuiteEntry {
+  id: string;
+  testName: string;
+  description: string;
+  url: string;
+  testCode: string;
+  testFilePath?: string;
+  artifacts: SuiteEntryArtifacts;
+  metrics: SuiteEntryMetrics;
+  version: number;
+  createdAt: string;
+}

--- a/packages/core/src/suite/SuiteManager.test.ts
+++ b/packages/core/src/suite/SuiteManager.test.ts
@@ -1,0 +1,166 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  readdir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+}));
+
+import type { SuiteEntry } from './SuiteEntry.js';
+import { SuiteManager } from './SuiteManager.js';
+
+const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
+const mockReaddir = readdir as unknown as ReturnType<typeof vi.fn>;
+const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
+
+function createEntry(overrides: Partial<SuiteEntry> = {}): SuiteEntry {
+  return {
+    id: 'test-id-1',
+    testName: 'login-test',
+    description: 'Test login flow',
+    url: 'https://example.com/login',
+    testCode: 'test("login", async () => {});',
+    artifacts: { pomMd: '# POM', gherkinMd: '# Gherkin', cucumberMd: '# Cucumber' },
+    metrics: {
+      totalTokensUsed: 1000,
+      totalCost: 0.005,
+      modelFast: 'gpt-4o-mini',
+      modelStrong: 'gpt-4o',
+      explorationRounds: 5,
+      generationAttempts: 1,
+      timestamp: '2026-01-01T00:00:00.000Z',
+    },
+    version: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('SuiteManager', () => {
+  const baseDir = '/project';
+  let manager: SuiteManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    manager = new SuiteManager(baseDir);
+  });
+
+  describe('save', () => {
+    it('creates directory and writes latest + history for a new entry', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+      const entry = createEntry();
+
+      await manager.save(entry);
+
+      const testDir = join(baseDir, '.ppia', 'suite', 'login-test');
+      expect(mockMkdir).toHaveBeenCalledWith(testDir, { recursive: true });
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        join(testDir, 'latest.json'),
+        JSON.stringify(entry, null, 2),
+        'utf-8',
+      );
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        join(testDir, 'history.json'),
+        JSON.stringify([entry], null, 2),
+        'utf-8',
+      );
+    });
+
+    it('appends to existing history', async () => {
+      const v1 = createEntry({ id: 'v1', version: 1 });
+      const v2 = createEntry({ id: 'v2', version: 2 });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([v1]));
+
+      await manager.save(v2);
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('history.json'),
+        JSON.stringify([v1, v2], null, 2),
+        'utf-8',
+      );
+    });
+  });
+
+  describe('list', () => {
+    it('returns empty array when suite directory does not exist', async () => {
+      mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await manager.list();
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns latest entries for all tests', async () => {
+      const entry1 = createEntry({ testName: 'test-a' });
+      const entry2 = createEntry({ testName: 'test-b' });
+      mockReaddir.mockResolvedValueOnce(['test-a', 'test-b']);
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(entry1))
+        .mockResolvedValueOnce(JSON.stringify(entry2));
+
+      const result = await manager.list();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.testName).toBe('test-a');
+      expect(result[1]?.testName).toBe('test-b');
+    });
+
+    it('skips entries that fail to read', async () => {
+      const entry1 = createEntry({ testName: 'test-a' });
+      mockReaddir.mockResolvedValueOnce(['test-a', 'broken']);
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(entry1))
+        .mockRejectedValueOnce(new Error('corrupt'));
+
+      const result = await manager.list();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.testName).toBe('test-a');
+    });
+  });
+
+  describe('getById', () => {
+    it('returns the latest entry for a test name', async () => {
+      const entry = createEntry();
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(entry));
+
+      const result = await manager.getById('login-test');
+
+      expect(result).toEqual(entry);
+    });
+
+    it('returns undefined when test does not exist', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await manager.getById('nonexistent');
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('getVersions', () => {
+    it('returns full history for a test', async () => {
+      const v1 = createEntry({ id: 'v1', version: 1 });
+      const v2 = createEntry({ id: 'v2', version: 2 });
+      mockReadFile.mockResolvedValueOnce(JSON.stringify([v1, v2]));
+
+      const result = await manager.getVersions('login-test');
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.version).toBe(1);
+      expect(result[1]?.version).toBe(2);
+    });
+
+    it('returns empty array when no history exists', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const result = await manager.getVersions('nonexistent');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/suite/SuiteManager.test.ts
+++ b/packages/core/src/suite/SuiteManager.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
@@ -6,6 +6,7 @@ vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),
   readdir: vi.fn(),
   readFile: vi.fn(),
+  rm: vi.fn(),
   writeFile: vi.fn(),
 }));
 
@@ -15,6 +16,7 @@ import { SuiteManager } from './SuiteManager.js';
 const mockMkdir = mkdir as unknown as ReturnType<typeof vi.fn>;
 const mockReaddir = readdir as unknown as ReturnType<typeof vi.fn>;
 const mockReadFile = readFile as unknown as ReturnType<typeof vi.fn>;
+const mockRm = rm as unknown as ReturnType<typeof vi.fn>;
 const mockWriteFile = writeFile as unknown as ReturnType<typeof vi.fn>;
 
 function createEntry(overrides: Partial<SuiteEntry> = {}): SuiteEntry {
@@ -161,6 +163,48 @@ describe('SuiteManager', () => {
       const result = await manager.getVersions('nonexistent');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('clean', () => {
+    it('removes tests older than the specified number of days', async () => {
+      const oldDate = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+      const recentDate = new Date().toISOString();
+      const oldEntry = createEntry({ testName: 'old-test', createdAt: oldDate });
+      const recentEntry = createEntry({ testName: 'recent-test', createdAt: recentDate });
+
+      mockReaddir.mockResolvedValueOnce(['old-test', 'recent-test']);
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(oldEntry))
+        .mockResolvedValueOnce(JSON.stringify(recentEntry));
+
+      const removed = await manager.clean(30);
+
+      expect(removed).toBe(1);
+      expect(mockRm).toHaveBeenCalledTimes(1);
+      expect(mockRm).toHaveBeenCalledWith(
+        join(baseDir, '.ppia', 'suite', 'old-test'),
+        { recursive: true, force: true },
+      );
+    });
+
+    it('returns 0 when no tests are older than threshold', async () => {
+      const recentEntry = createEntry({ createdAt: new Date().toISOString() });
+      mockReaddir.mockResolvedValueOnce(['recent-test']);
+      mockReadFile.mockResolvedValueOnce(JSON.stringify(recentEntry));
+
+      const removed = await manager.clean(30);
+
+      expect(removed).toBe(0);
+      expect(mockRm).not.toHaveBeenCalled();
+    });
+
+    it('returns 0 when suite directory does not exist', async () => {
+      mockReaddir.mockRejectedValueOnce(new Error('ENOENT'));
+
+      const removed = await manager.clean(30);
+
+      expect(removed).toBe(0);
     });
   });
 });

--- a/packages/core/src/suite/SuiteManager.ts
+++ b/packages/core/src/suite/SuiteManager.ts
@@ -1,0 +1,78 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import type { SuiteEntry } from './SuiteEntry.js';
+
+export class SuiteManager {
+  private readonly suiteDir: string;
+
+  constructor(private readonly baseDir: string) {
+    this.suiteDir = join(baseDir, '.ppia', 'suite');
+  }
+
+  async save(entry: SuiteEntry): Promise<void> {
+    const testDir = join(this.suiteDir, entry.testName);
+    await mkdir(testDir, { recursive: true });
+
+    const latestPath = join(testDir, 'latest.json');
+    const historyPath = join(testDir, 'history.json');
+
+    // Write latest
+    await writeFile(latestPath, JSON.stringify(entry, null, 2), 'utf-8');
+
+    // Append to history
+    const history = await this.readHistory(historyPath);
+    history.push(entry);
+    await writeFile(historyPath, JSON.stringify(history, null, 2), 'utf-8');
+  }
+
+  async list(): Promise<SuiteEntry[]> {
+    const entries: SuiteEntry[] = [];
+
+    let dirNames: string[];
+    try {
+      dirNames = await readdir(this.suiteDir);
+    } catch {
+      return entries;
+    }
+
+    for (const name of dirNames) {
+      const entry = await this.readLatest(name);
+      if (entry) {
+        entries.push(entry);
+      }
+    }
+
+    return entries;
+  }
+
+  async getById(testName: string): Promise<SuiteEntry | undefined> {
+    return this.readLatest(testName);
+  }
+
+  async getVersions(testName: string): Promise<SuiteEntry[]> {
+    const historyPath = join(this.suiteDir, testName, 'history.json');
+    return this.readHistory(historyPath);
+  }
+
+  // ── Private helpers ──────────────────────────────────────────────────
+
+  private async readLatest(testName: string): Promise<SuiteEntry | undefined> {
+    const latestPath = join(this.suiteDir, testName, 'latest.json');
+    try {
+      const raw = await readFile(latestPath, 'utf-8');
+      return JSON.parse(raw) as SuiteEntry;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async readHistory(historyPath: string): Promise<SuiteEntry[]> {
+    try {
+      const raw = await readFile(historyPath, 'utf-8');
+      return JSON.parse(raw) as SuiteEntry[];
+    } catch {
+      return [];
+    }
+  }
+}

--- a/packages/core/src/suite/SuiteManager.ts
+++ b/packages/core/src/suite/SuiteManager.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import type { SuiteEntry } from './SuiteEntry.js';
@@ -53,6 +53,33 @@ export class SuiteManager {
   async getVersions(testName: string): Promise<SuiteEntry[]> {
     const historyPath = join(this.suiteDir, testName, 'history.json');
     return this.readHistory(historyPath);
+  }
+
+  async clean(olderThanDays: number): Promise<number> {
+    const cutoff = Date.now() - olderThanDays * 24 * 60 * 60 * 1000;
+    let removed = 0;
+
+    let dirNames: string[];
+    try {
+      dirNames = await readdir(this.suiteDir);
+    } catch {
+      return 0;
+    }
+
+    for (const name of dirNames) {
+      const latest = await this.readLatest(name);
+      if (!latest) {
+        continue;
+      }
+
+      const createdMs = new Date(latest.createdAt).getTime();
+      if (createdMs < cutoff) {
+        await rm(join(this.suiteDir, name), { recursive: true, force: true });
+        removed++;
+      }
+    }
+
+    return removed;
   }
 
   // ── Private helpers ──────────────────────────────────────────────────

--- a/packages/core/src/suite/index.ts
+++ b/packages/core/src/suite/index.ts
@@ -1,1 +1,4 @@
-// Suite: test suite management, history and knowledge base client.
+export { KnowledgeBase } from './KnowledgeBase.js';
+export type { KnowledgeEntry, ResetOptions } from './KnowledgeEntry.js';
+export { SuiteManager } from './SuiteManager.js';
+export type { SuiteEntry, SuiteEntryArtifacts, SuiteEntryMetrics } from './SuiteEntry.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2242 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  packages/core:
+    dependencies:
+      '@inquirer/prompts':
+        specifier: ^8.3.0
+        version: 8.3.0(@types/node@22.19.13)
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
+      commander:
+        specifier: ^14.0.3
+        version: 14.0.3
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.18.0
+        version: 9.39.3
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.13
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.3
+      playwright:
+        specifier: ^1.58.2
+        version: 1.58.2
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.20.0
+        version: 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.13)(yaml@2.8.2)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.21.1':
+    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/eslintrc@3.3.4':
+    resolution: {integrity: sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/js@9.39.3':
+    resolution: {integrity: sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/object-schema@2.1.7':
+    resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@humanfs/core@0.19.1':
+    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.7':
+    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
+
+  '@inquirer/ansi@2.0.3':
+    resolution: {integrity: sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/checkbox@5.1.0':
+    resolution: {integrity: sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.0.8':
+    resolution: {integrity: sha512-Di6dgmiZ9xCSUxWUReWTqDtbhXCuG2MQm2xmgSAIruzQzBqNf49b8E07/vbCYY506kDe8BiwJbegXweG8M1klw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.1.5':
+    resolution: {integrity: sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.0.8':
+    resolution: {integrity: sha512-sLcpbb9B3XqUEGrj1N66KwhDhEckzZ4nI/W6SvLXyBX8Wic3LDLENlWRvkOGpCPoserabe+MxQkpiMoI8irvyA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.0.8':
+    resolution: {integrity: sha512-QieW3F1prNw3j+hxO7/NKkG1pk3oz7pOB6+5Upwu3OIwADfPX0oZVppsqlL+Vl/uBHHDSOBY0BirLctLnXwGGg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@2.0.3':
+    resolution: {integrity: sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.3':
+    resolution: {integrity: sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+
+  '@inquirer/input@5.0.8':
+    resolution: {integrity: sha512-p0IJslw0AmedLEkOU+yrEX3Aj2RTpQq7ZOf8nc1DIhjzaxRWrrgeuE5Kyh39fVRgtcACaMXx/9WNo8+GjgBOfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.0.8':
+    resolution: {integrity: sha512-uGLiQah9A0F9UIvJBX52m0CnqtLaym0WpT9V4YZrjZ+YRDKZdwwoEPz06N6w8ChE2lrnsdyhY9sL+Y690Kh9gQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.0.8':
+    resolution: {integrity: sha512-zt1sF4lYLdvPqvmvHdmjOzuUUjuCQ897pdUCO8RbXMUDKXJTTyOQgtn23le+jwcb+MpHl3VAFvzIdxRAf6aPlA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.3.0':
+    resolution: {integrity: sha512-JAj66kjdH/F1+B7LCigjARbwstt3SNUOSzMdjpsvwJmzunK88gJeXmcm95L9nw1KynvFVuY4SzXh/3Y0lvtgSg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.2.4':
+    resolution: {integrity: sha512-fTuJ5Cq9W286isLxwj6GGyfTjx1Zdk4qppVEPexFuA6yioCCXS4V1zfKroQqw7QdbDPN73xs2DiIAlo55+kBqg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.1.4':
+    resolution: {integrity: sha512-9yPTxq7LPmYjrGn3DRuaPuPbmC6u3fiWcsE9ggfLcdgO/ICHYgxq7mEy1yJ39brVvgXhtOtvDVjDh9slJxE4LQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.1.0':
+    resolution: {integrity: sha512-OyYbKnchS1u+zRe14LpYrN8S0wH1vD0p2yKISvSsJdH2TpI87fh4eZdWnpdbrGauCRWDph3NwxRmM4Pcm/hx1Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.3':
+    resolution: {integrity: sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@22.19.13':
+    resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
+
+  '@typescript-eslint/eslint-plugin@8.56.1':
+    resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.56.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/parser@8.56.1':
+    resolution: {integrity: sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/project-service@8.56.1':
+    resolution: {integrity: sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/scope-manager@8.56.1':
+    resolution: {integrity: sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.56.1':
+    resolution: {integrity: sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.56.1':
+    resolution: {integrity: sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/types@8.56.1':
+    resolution: {integrity: sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.56.1':
+    resolution: {integrity: sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.56.1':
+    resolution: {integrity: sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.56.1':
+    resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@8.4.0:
+    resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@9.39.3:
+    resolution: {integrity: sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.3.4:
+    resolution: {integrity: sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  playwright-core@1.58.2:
+    resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.58.2:
+    resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  ts-api-utils@2.4.0:
+    resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  typescript-eslint@8.56.1:
+    resolution: {integrity: sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3)':
+    dependencies:
+      eslint: 9.39.3
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.21.1':
+    dependencies:
+      '@eslint/object-schema': 2.1.7
+      debug: 4.4.3
+      minimatch: 3.1.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.4.2':
+    dependencies:
+      '@eslint/core': 0.17.0
+
+  '@eslint/core@0.17.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/eslintrc@3.3.4':
+    dependencies:
+      ajv: 6.14.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@9.39.3': {}
+
+  '@eslint/object-schema@2.1.7': {}
+
+  '@eslint/plugin-kit@0.4.1':
+    dependencies:
+      '@eslint/core': 0.17.0
+      levn: 0.4.1
+
+  '@humanfs/core@0.19.1': {}
+
+  '@humanfs/node@0.16.7':
+    dependencies:
+      '@humanfs/core': 0.19.1
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
+
+  '@inquirer/ansi@2.0.3': {}
+
+  '@inquirer/checkbox@5.1.0(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/confirm@6.0.8(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/core@11.1.5(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.0
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/editor@5.0.8(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/external-editor': 2.0.3(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/expand@5.0.8(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/external-editor@2.0.3(@types/node@22.19.13)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/figures@2.0.3': {}
+
+  '@inquirer/input@5.0.8(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/number@4.0.8(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/password@5.0.8(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/prompts@8.3.0(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/checkbox': 5.1.0(@types/node@22.19.13)
+      '@inquirer/confirm': 6.0.8(@types/node@22.19.13)
+      '@inquirer/editor': 5.0.8(@types/node@22.19.13)
+      '@inquirer/expand': 5.0.8(@types/node@22.19.13)
+      '@inquirer/input': 5.0.8(@types/node@22.19.13)
+      '@inquirer/number': 4.0.8(@types/node@22.19.13)
+      '@inquirer/password': 5.0.8(@types/node@22.19.13)
+      '@inquirer/rawlist': 5.2.4(@types/node@22.19.13)
+      '@inquirer/search': 4.1.4(@types/node@22.19.13)
+      '@inquirer/select': 5.1.0(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/rawlist@5.2.4(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/search@4.1.4(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/select@5.1.0(@types/node@22.19.13)':
+    dependencies:
+      '@inquirer/ansi': 2.0.3
+      '@inquirer/core': 11.1.5(@types/node@22.19.13)
+      '@inquirer/figures': 2.0.3
+      '@inquirer/type': 4.0.3(@types/node@22.19.13)
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@inquirer/type@4.0.3(@types/node@22.19.13)':
+    optionalDependencies:
+      '@types/node': 22.19.13
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@22.19.13':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/type-utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.1
+      eslint: 9.39.3
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.56.1
+      debug: 4.4.3
+      eslint: 9.39.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.56.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.56.1':
+    dependencies:
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/visitor-keys': 8.56.1
+
+  '@typescript-eslint/tsconfig-utils@8.56.1(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.56.1(eslint@9.39.3)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 9.39.3
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.56.1': {}
+
+  '@typescript-eslint/typescript-estree@8.56.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/visitor-keys': 8.56.1
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.4.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.56.1(eslint@9.39.3)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3)
+      '@typescript-eslint/scope-manager': 8.56.1
+      '@typescript-eslint/types': 8.56.1
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      eslint: 9.39.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.56.1':
+    dependencies:
+      '@typescript-eslint/types': 8.56.1
+      eslint-visitor-keys: 5.0.1
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.13)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.13)(yaml@2.8.2)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
+
+  cac@6.7.14: {}
+
+  callsites@3.1.0: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  chardet@2.1.1: {}
+
+  check-error@2.1.3: {}
+
+  cli-width@4.1.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@14.0.3: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  deep-is@0.1.4: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@8.4.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@9.39.3:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.21.1
+      '@eslint/config-helpers': 0.4.2
+      '@eslint/core': 0.17.0
+      '@eslint/eslintrc': 3.3.4
+      '@eslint/js': 9.39.3
+      '@eslint/plugin-kit': 0.4.1
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
+
+  expect-type@1.3.0: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.4
+      keyv: 4.5.4
+
+  flatted@3.3.4: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  has-flag@4.0.0: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
+
+  minimatch@3.1.5:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  ms@2.1.3: {}
+
+  mute-stream@3.0.0: {}
+
+  nanoid@3.3.11: {}
+
+  natural-compare@1.4.0: {}
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  playwright-core@1.58.2: {}
+
+  playwright@1.58.2:
+    dependencies:
+      playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  resolve-from@4.0.0: {}
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  safer-buffer@2.1.2: {}
+
+  semver@7.7.4: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  ts-api-utils@2.4.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  typescript-eslint@8.56.1(eslint@9.39.3)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3)(typescript@5.9.3))(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3)(typescript@5.9.3)
+      eslint: 9.39.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  vite-node@3.2.4(@types/node@22.19.13)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.13)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1(@types/node@22.19.13)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.13
+      fsevents: 2.3.3
+      yaml: 2.8.2
+
+  vitest@3.2.4(@types/node@22.19.13)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.13)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.13)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@22.19.13)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.13
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  word-wrap@1.2.5: {}
+
+  yaml@2.8.2: {}
+
+  yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
 
   packages/core:
     dependencies:
@@ -1034,6 +1038,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2092,6 +2100,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary

Release que incluye todas las tareas acumuladas en develop:

- **T13** — `ppia setup` CLI con gestión interactiva de configuraciones de autenticación
- **T14** — `ppia generate` CLI con progreso en tiempo real y tracking de costes + integración SuiteManager
- **T15** — SuiteManager y KnowledgeBase con persistencia JSON en `.ppia/`
- **T17** — CLI: `ppia knowledge`, `ppia suite`, `ppia config`
- **T18** — CI/CD: GitHub Actions (CI en PRs, release automática en master)
- **T19** — Tests unitarios TypeScript: 134 tests, pre-push hook con nvm
- **T20** — Tests unitarios Python: 42 tests, pre-push hook con venv
- **T14 (fix)** — Integración SuiteManager.save() en generate
- **T26** — `ppia init` con configuración interactiva de IA (mix libre de proveedores/modelos)

## QA

- 134 tests TypeScript (Vitest)
- 42 tests Python (pytest)
- ESLint + tsc --noEmit
- ruff + mypy --strict
- Pre-push hook: TS + Python QA completa

## Test plan
- [x] CI green en PR
- [x] All unit tests passing
- [x] Pre-push hook validated locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)