### PR TITLE
fix(ai): replace __dirname with ESM-compatible import.meta.url

### DIFF
--- a/packages/core/src/ai/PythonServerManager.ts
+++ b/packages/core/src/ai/PythonServerManager.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { AiServiceError } from './AiServiceError.js';
 
@@ -49,7 +50,8 @@ export class PythonServerManager {
       return;
     }
 
-    const pythonDir = resolve(__dirname, '../../python');
+    const currentDir = dirname(fileURLToPath(import.meta.url));
+    const pythonDir = resolve(currentDir, '../../python');
 
     this.process = spawn(
       this.pythonPath,


### PR DESCRIPTION
## Summary
- Fix `__dirname is not defined` error when running `ppia generate`
- Replace CommonJS `__dirname` with ESM `import.meta.url` in PythonServerManager

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] 134 TypeScript + 42 Python tests pass

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)