### PR TITLE
docs(sdd): add Spec-Driven Development docs for 4 task groups

### DIFF
--- a/docs/sdd/ai-service-runtime/design.md
+++ b/docs/sdd/ai-service-runtime/design.md
@@ -1,0 +1,167 @@
+# T24 — Design: Startup Check
+## Health Check, Price Scraping, and Cost Estimation
+
+> Last updated: 2026-03-17
+
+---
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as TypeScript CLI<br/>(StartupChecker)
+    participant Cache as .ppia/last-startup.json
+    participant Proc as Python Process<br/>(subprocess)
+    participant Health as GET /ping
+    participant PriceCache as .ppia/llm-pricing.json
+    participant Adapter as PricingAdapter<br/>(OpenRouter)
+    participant OR as openrouter.ai/api/v1/models
+    participant Estimator as CostEstimator
+    participant Display as ProgressDisplay
+
+    User->>CLI: ppia generate "..."
+
+    CLI->>Cache: read last-startup.json
+    alt Already ran today
+        Cache-->>CLI: ran_at = today → skip
+    else First run today
+        CLI->>Proc: spawn python -m ppia_ai.server
+        loop Retry up to 10× / 300 ms
+            CLI->>Health: GET /ping
+            Health-->>CLI: 200 { status: ok, version }
+        end
+
+        CLI->>PriceCache: read llm-pricing.json
+        alt Cache valid (fetched_at = today)
+            PriceCache-->>CLI: prices (cached)
+        else Cache missing or stale
+            CLI->>Adapter: fetch_prices(models)
+            Adapter->>OR: GET /api/v1/models
+            OR-->>Adapter: JSON model list
+            Adapter-->>CLI: PricingResult
+            CLI->>PriceCache: atomic write llm-pricing.json
+        end
+
+        CLI->>Estimator: estimate_cost(estimated_actions, prices)
+        Estimator-->>CLI: CostEstimate
+
+        CLI->>Display: renderStartupPanel(result)
+        Display-->>User: panel (versions · keys · prices · estimate)
+
+        CLI->>Cache: write last-startup.json { ran_at: today }
+    end
+
+    CLI->>CLI: continue → ppia generate flow
+```
+
+---
+
+## Component Breakdown
+
+### Python AI Service
+
+#### `GET /ping` — Health Endpoint
+- **Location**: `packages/core/python/src/server.py`
+- Registered before any slow initialization so health check is always fast.
+- Response: `{ "status": "ok", "version": "<semver>" }`
+
+#### `PricingPort` — Domain Interface
+- **Location**: `packages/core/python/src/domain/repository/pricing_port.py`
+- Abstract base class following the existing `LlmService` port pattern.
+
+#### `ModelPrice` — Domain Model
+- **Location**: `packages/core/python/src/domain/model/model_price.py`
+- Pydantic model. Fields: `model_id`, `input_usd_per_token`, `output_usd_per_token`, `context_length`, `fetched_at` (ISO date UTC).
+
+#### `PricingAdapter` — Infrastructure (OpenRouter)
+- **Location**: `packages/core/python/src/infrastructure/pricing/openrouter_pricing_adapter.py`
+- Implements `PricingPort` via `httpx.AsyncClient`.
+- Filters OpenRouter model list to requested `model_ids`.
+- Returns empty list on any network or parse error (triggering fallback).
+
+#### `PricingStore` — Infrastructure (Cache)
+- **Location**: `packages/core/python/src/infrastructure/pricing/pricing_store.py`
+- Reads/writes `.ppia/llm-pricing.json` relative to `project_root`.
+- Atomic write: write to `.tmp` then rename.
+- Cache schema: `{ "schema_version": 1, "models": { "<id>": ModelPrice } }`
+
+#### `CostEstimator` — Application Use Case
+- **Location**: `packages/core/python/src/application/use_cases/startup/cost_estimator.py`
+- Pure function. Receives prices and `estimated_actions`, returns `CostEstimate`.
+- Token budget constants in `token_budgets.py` (`AVG_TOKENS_PER_ACTION = 2_500`, `AVG_TOKENS_GENERATION = 8_000`).
+
+---
+
+### TypeScript CLI
+
+#### `StartupChecker` — Orchestrator
+- **Location**: `packages/core/src/cli/StartupChecker.ts`
+- Coordinates: spawn Python → health poll → price fetch → cost estimate → display → write gate.
+
+#### `PricingFetcher`
+- **Location**: `packages/core/src/ai/PricingFetcher.ts`
+- Node.js `fetch` to OpenRouter + daily cache R/W (atomic).
+
+#### `CostEstimator` (TypeScript)
+- **Location**: `packages/core/src/domain/CostEstimator.ts`
+- Pure function mirroring the Python counterpart.
+
+#### `LastStartupStore`
+- **Location**: `packages/core/src/cli/LastStartupStore.ts`
+- Reads/writes `.ppia/last-startup.json`. `hasRanToday(): boolean`.
+
+#### `ProgressDisplay` — Extension
+- **Location**: `packages/core/src/cli/ui/ProgressDisplay.ts`
+- New method: `renderStartupPanel(result: StartupResult): void`.
+
+---
+
+## ADR-01 — Price Data Source: OpenRouter vs. llm-prices.com
+
+**Elegido**: `openrouter.ai/api/v1/models`
+**Descartado**: `llm-prices.com` (HTML scraping)
+**Motivo**: OpenRouter devuelve JSON estructurado sin necesidad de parsear HTML. Cubre todos los modelos OpenAI y Anthropic relevantes. No requiere autenticación para datos de precios públicos.
+**Consecuencias**: Si OpenRouter cambia el schema, el adapter falla silenciosamente (fallback a cache). Los `model_id` de OpenRouter (`openai/gpt-4o-mini`) deben mapearse a los nombres de `ppia.yaml`.
+
+---
+
+## ADR-02 — Caching Strategy: File-Based Daily Cache
+
+**Elegido**: Cache en fichero con clave de fecha UTC (`.ppia/llm-pricing.json`)
+**Descartado**: Sin cache (siempre fetch), in-memory, TTL de 24h
+**Motivo**: Los precios cambian raramente. La cache en fichero sobrevive reinicios y funciona offline. La fecha UTC es simple y determinista.
+**Consecuencias**: Primer `ppia generate` del día (UTC) hace una llamada de red (<100ms). El resto del día usa cache.
+
+---
+
+## ADR-03 — Display: Panel Inline Once-Per-Day vs. Comando Separado
+
+**Elegido**: Panel inline mostrado **una vez por día** (gate FR-06)
+**Descartado**: Mostrar siempre, mostrar solo en `ppia status`
+**Motivo**: Mostrar siempre añade ruido. Esconder en un comando separado hace que el usuario nunca vea las estimaciones de coste. Una vez al día es el equilibrio.
+**Consecuencias**: Los usuarios pueden forzar un refresh eliminando `.ppia/last-startup.json`.
+
+---
+
+## Consideraciones de Seguridad
+
+| Preocupación | Mitigación |
+|---|---|
+| API keys en logs | `ProgressDisplay` solo muestra `✅ configured` / `❌ not set` — nunca el valor |
+| API keys en HTTP bodies | Las keys se pasan via variables de entorno al subprocess Python, nunca en request bodies |
+| Datos de precios | OpenRouter pricing data es pública — sin tratamiento especial |
+| Permisos del fichero cache | `.ppia/llm-pricing.json` no contiene secrets — permisos estándar |
+| stderr del subprocess | Capturado y mostrado solo en caso de fallo de startup |
+
+---
+
+## Riesgos Técnicos
+
+| # | Riesgo | Prob. | Impacto | Mitigación |
+|---|---|---|---|---|
+| R1 | OpenRouter API no disponible o schema cambiado | Baja | Medio | Fallback silencioso a cache existente. Si no hay cache: "prices unavailable" y continuar. |
+| R2 | Startup check > 3s (red lenta) | Media | Bajo | `fetch` con timeout de 2s. Si excede: skip y usar cache. Health check: timeout total de 3s. |
+| R3 | Cache stale → estimaciones imprecisas | Baja | Bajo | Cache invalidada diariamente. Estimaciones claramente marcadas como "estimated". |
+| R4 | Python process no arranca (venv ausente, Python version incorrecta) | Media | Alto | TypeScript verifica versión de Python antes de lanzar. stderr capturado y mostrado verbatim. |
+| R5 | model_id OpenRouter no coincide con nombre en ppia.yaml | Media | Medio | `PricingAdapter` normaliza IDs (quita prefijo de proveedor). Fallback a "price unknown" por modelo. |

--- a/docs/sdd/ai-service-runtime/requirements.md
+++ b/docs/sdd/ai-service-runtime/requirements.md
@@ -1,0 +1,101 @@
+# T24 — Requirements: Startup Check
+## Health Check, Price Scraping, and Cost Estimation
+
+> Format: EARS (Easy Approach to Requirements Syntax)
+> Last updated: 2026-03-17
+
+---
+
+## Functional Requirements
+
+### FR-01 — Health Endpoint (MUST)
+
+**When** the Python AI Service starts, **the system shall** expose a `GET /ping` endpoint that returns `{ "status": "ok", "version": "<semver>" }` with HTTP 200.
+
+**When** the TypeScript CLI polls `GET /ping` after spawning the Python process, **the system shall** retry up to 10 times at 300 ms intervals and consider the service ready on the first successful 200 response.
+
+**If** the Python AI Service does not respond with HTTP 200 within 3 seconds of the first spawn attempt, **the system shall** abort startup and display a human-readable error message that includes the process stderr output.
+
+---
+
+### FR-02 — Price Scraping (MUST)
+
+**When** the startup check runs and no valid cache exists for today, **the system shall** fetch model pricing data from `https://openrouter.ai/api/v1/models` using a plain HTTP GET request (no browser required).
+
+**The system shall** extract, for each configured model (`model_fast` and `model_strong`), the following fields:
+- `prompt` cost (USD per token)
+- `completion` cost (USD per token)
+- `context_length` (tokens)
+
+**If** the HTTP request fails or the response does not contain pricing for a configured model, **the system shall** fall back silently to the existing `.ppia/llm-pricing.json` cache without surfacing an error to the user.
+
+---
+
+### FR-03 — Price Cache (MUST)
+
+**When** price scraping succeeds, **the system shall** write the result to `.ppia/llm-pricing.json` relative to `--project-root`, including a `fetched_at` ISO-8601 timestamp per model.
+
+**When** the startup check runs and `.ppia/llm-pricing.json` exists with a `fetched_at` date equal to today (UTC), **the system shall** skip the HTTP fetch and read prices from the cache directly.
+
+**The system shall** never overwrite the cache with partial data — the write must be atomic (write to a temp file, then rename).
+
+---
+
+### FR-04 — Cost Estimation (MUST)
+
+**When** the `POST /prepare-input` response is available, **the system shall** compute a per-session cost estimate using the formula:
+
+```
+exploration_cost = estimated_actions × avg_tokens_per_action × model_fast_price
+generation_cost  = 1 × avg_tokens_generation × model_strong_price
+total_estimated  = exploration_cost + generation_cost
+```
+
+Default token budgets (overridable in `ppia.yaml`):
+- `avg_tokens_per_action`: 2 500 (input + output combined)
+- `avg_tokens_generation`: 8 000
+
+**The system shall** return `estimated_cost` (USD, float, 4 decimal places) in the `/prepare-input` response.
+
+---
+
+### FR-05 — Startup Display (MUST)
+
+**When** the startup check completes, **the TypeScript CLI shall** display a startup panel to the terminal that includes:
+
+1. Tool versions (Node.js, Python, AI Service)
+2. API key presence — `✅ configured` or `❌ not set` (never the key value)
+3. Current prices for `model_fast` and `model_strong` (input / output per MTok)
+4. Cost estimate for the current session, broken down by phase (exploration / generation / total)
+
+**If** prices are sourced from cache (not freshly scraped), **the system shall** append `(cached)` to the price display.
+
+---
+
+### FR-06 — Once-Per-Day Gate (SHOULD)
+
+**When** `ppia generate` is invoked, **the system shall** check `.ppia/last-startup.json` for a `ran_at` date equal to today (UTC).
+
+**If** the gate condition is met (already ran today), **the system shall** skip FR-02 through FR-05 and proceed directly to the main flow.
+
+**When** the startup check runs to completion without error, **the system shall** write `.ppia/last-startup.json` with `{ "ran_at": "<ISO date UTC>", "version": "<semver>" }`.
+
+---
+
+## Non-Functional Requirements
+
+### NFR-01 — Performance
+The complete startup check shall complete within **3 seconds** on a standard broadband connection. The health check phase alone shall complete within **1 second** of the Python process being ready.
+
+### NFR-02 — Security
+- API key values **shall never** appear in any log file, terminal output, or HTTP response body.
+- The CLI shall display only `✅ configured` or `❌ not set` per key.
+- The `.ppia/llm-pricing.json` cache shall not contain any secret or credential.
+
+### NFR-03 — Maintainability
+- The pricing adapter shall implement a `PricingPort` interface (domain layer) so the data source can be swapped without touching application logic.
+- Token budget defaults shall be defined as named constants in a single location.
+- The price cache schema shall be versioned (`"schema_version": 1`) to allow future migrations.
+
+### NFR-04 — Resilience
+The startup check shall be fully non-blocking for the main flow: any failure in price scraping or cost estimation shall degrade gracefully to "prices unavailable" and shall not prevent `ppia generate` from proceeding.

--- a/docs/sdd/ai-service-runtime/tasks.md
+++ b/docs/sdd/ai-service-runtime/tasks.md
@@ -1,0 +1,159 @@
+# T24 — Tasks: Startup Check
+## Health Check, Price Scraping, and Cost Estimation
+
+> Last updated: 2026-03-17
+
+---
+
+## Resumen de subtareas
+
+| ID | Título | Tamaño | Depende de |
+|---|---|---|---|
+| T24.1 | Python health endpoint hardening + `/startup-info` | S | — |
+| T24.2 | Python pricing port, domain model y OpenRouter adapter | M | T24.1 |
+| T24.3 | Python cost estimator use case + token budget constants | S | T24.2 |
+| T24.4 | TypeScript `StartupChecker`: spawn, health poll, price fetch, cache | M | T24.1 |
+| T24.5 | TypeScript display + once-per-day gate + wiring | S | T24.3, T24.4 |
+
+---
+
+## T24.1 — Python health endpoint hardening + `/startup-info`
+
+**Tamaño**: S
+**Depende**: ninguna
+
+Garantizar que `/ping` está disponible inmediatamente después del start del proceso (antes de cualquier init lento). Añadir endpoint `/startup-info` ligero.
+
+**Ficheros afectados**:
+- `packages/core/python/src/server.py` — reordenar init; añadir `GET /startup-info`
+- `packages/core/python/src/application/dto/startup.py` (nuevo) — `StartupInfoResponse`
+- `packages/core/python/tests/test_startup_endpoints.py` (nuevo)
+
+**Criterios de aceptación**:
+- [ ] `GET /ping` devuelve 200 en < 50 ms incluso si `ppia.yaml` loading es lento
+- [ ] `GET /startup-info` devuelve `{ version, model_fast, model_strong }`
+- [ ] Tests pasan con `pytest`; `mypy --strict` limpio
+
+---
+
+## T24.2 — Python pricing port, domain model y OpenRouter adapter
+
+**Tamaño**: M
+**Depende**: T24.1
+
+Implementar la capa de infraestructura de precios siguiendo la arquitectura hexagonal existente.
+
+**Ficheros afectados**:
+- `packages/core/python/src/domain/repository/pricing_port.py` (nuevo) — `PricingPort` ABC
+- `packages/core/python/src/domain/model/model_price.py` (nuevo) — `ModelPrice`
+- `packages/core/python/src/infrastructure/pricing/openrouter_pricing_adapter.py` (nuevo)
+- `packages/core/python/src/infrastructure/pricing/pricing_store.py` (nuevo) — atomic write
+- `packages/core/python/src/infrastructure/config/dependency_injection.py` — registrar binding
+- Tests: `test_openrouter_adapter.py`, `test_pricing_store.py` (nuevos)
+
+**Criterios de aceptación**:
+- [ ] `PricingAdapter.fetch_prices(["gpt-4o-mini", "claude-haiku-4-5"])` devuelve dos `ModelPrice` con valores no cero (test de integración, skippable offline)
+- [ ] `PricingStore` atomic write: si el proceso muere a mitad de escritura, el cache existente no se corrompe
+- [ ] Cache hit path no llama a HTTP (verificado con mock)
+- [ ] `mypy --strict` y `ruff check` pasan
+
+---
+
+## T24.3 — Python cost estimator use case + token budget constants
+
+**Tamaño**: S
+**Depende**: T24.2
+
+Implementar la lógica de estimación de coste como función pura en la capa de aplicación.
+
+**Ficheros afectados**:
+- `packages/core/python/src/application/use_cases/startup/token_budgets.py` (nuevo)
+- `packages/core/python/src/application/use_cases/startup/cost_estimator.py` (nuevo)
+- `packages/core/python/src/application/dto/prepare_input.py` — añadir campo `estimated_cost`
+- `packages/core/python/src/application/use_cases/prepare_input/prepare_input_use_case.py` — inyectar precios y llamar a `CostEstimator`
+- `packages/core/python/tests/application/startup/test_cost_estimator.py` (nuevo)
+
+**Criterios de aceptación**:
+- [ ] `estimate_cost(estimated_actions=12, ...)` devuelve `CostEstimate` con `exploration`, `generation` y `total`
+- [ ] `total == exploration + generation` (tolerancia 1e-8)
+- [ ] `estimated_cost` aparece en `PrepareInputResponse`
+- [ ] 100% branch coverage en `cost_estimator.py`
+
+---
+
+## T24.4 — TypeScript `StartupChecker`: spawn, health poll, price fetch, cache
+
+**Tamaño**: M
+**Depende**: T24.1
+
+Implementar la orquestación TypeScript del startup: spawn del proceso, retry loop de health, fetch de precios con cache diario, gate once-per-day.
+
+**Ficheros afectados**:
+- `packages/core/src/cli/StartupChecker.ts` (nuevo)
+- `packages/core/src/ai/PricingFetcher.ts` (nuevo)
+- `packages/core/src/domain/CostEstimator.ts` (nuevo)
+- `packages/core/src/cli/LastStartupStore.ts` (nuevo)
+- `packages/core/src/ai/AiServiceClient.ts` — añadir `waitForReady(timeoutMs: number)`
+- `packages/core/src/cli/commands/generate.ts` — llamar `StartupChecker.run()` antes del flujo principal
+- Tests: `StartupChecker.test.ts`, `PricingFetcher.test.ts` (nuevos)
+
+**Criterios de aceptación**:
+- [ ] Health retry: si Python no responde tras 10 intentos × 300 ms, lanza `StartupError` con stderr en el mensaje
+- [ ] Price fetch: si `llm-pricing.json` tiene fecha de hoy, `PricingFetcher` NO llama a `fetch`
+- [ ] `LastStartupStore.hasRanToday()` devuelve `true` tras `markRan()`
+- [ ] Todos los tests Vitest pasan; `tsc --noEmit` limpio
+
+---
+
+## T24.5 — TypeScript display + once-per-day gate + wiring
+
+**Tamaño**: S
+**Depende**: T24.3, T24.4
+
+Renderizar el panel de startup en el terminal y conectar el gate once-per-day en `ppia generate`.
+
+**Ficheros afectados**:
+- `packages/core/src/cli/ui/ProgressDisplay.ts` — añadir `renderStartupPanel(result: StartupResult)`
+- `packages/core/src/cli/commands/generate.ts` — gate + display + `markRan()`
+- `packages/core/tests/cli/ui/ProgressDisplay.test.ts` — snapshot test del panel
+- `packages/core/tests/cli/generate.integration.test.ts` (nuevo)
+
+**Criterios de aceptación**:
+- [ ] El panel de output sigue el formato del mockup en `ARCHITECTURE.md` (sección startup)
+- [ ] Los valores de API keys nunca aparecen en el output renderizado (test con key dummy)
+- [ ] Cuando `hasRanToday()` es `true`, `PricingFetcher.fetchPrices()` NO se llama (verificado con mock)
+- [ ] Suffix `(cached)` aparece cuando `StartupResult.pricesCached === true`
+
+---
+
+## Grafo de dependencias
+
+```mermaid
+graph TD
+    T24_1["T24.1<br/>Health endpoint hardening<br/>(S)"]
+    T24_2["T24.2<br/>Pricing port + adapter<br/>(M)"]
+    T24_3["T24.3<br/>Cost estimator use case<br/>(S)"]
+    T24_4["T24.4<br/>TypeScript StartupChecker<br/>(M)"]
+    T24_5["T24.5<br/>Display + gate + wiring<br/>(S)"]
+
+    T24_1 --> T24_2
+    T24_2 --> T24_3
+    T24_1 --> T24_4
+    T24_3 --> T24_5
+    T24_4 --> T24_5
+```
+
+*T24.4 puede desarrollarse en paralelo con T24.2+T24.3 (ambas parten de T24.1)*
+
+---
+
+## Resumen por tamaño
+
+| Tamaño | Cantidad | Subtareas |
+|---|---|---|
+| S | 3 | T24.1 · T24.3 · T24.5 |
+| M | 2 | T24.2 · T24.4 |
+
+**Camino crítico**: T24.1 → T24.2 → T24.3 → T24.5
+
+**Estimación**: T24.4 puede correr en paralelo con T24.2+T24.3 tras T24.1.

--- a/docs/sdd/ci-cd-hardening/design.md
+++ b/docs/sdd/ci-cd-hardening/design.md
@@ -1,0 +1,170 @@
+# Design — ci-cd-hardening
+
+> Group: T25, T28, T29
+> Last updated: 2026-03-17
+
+---
+
+## 1. AS-IS vs TO-BE
+
+### ci.yml
+
+```mermaid
+graph LR
+  subgraph AS-IS["ci.yml — AS-IS"]
+    A1["ci-typescript\nsetup-node@v4\n(no cache)"]
+    A2["ci-python\nsetup-python@v5\n(no cache)"]
+  end
+
+  subgraph TO-BE["ci.yml — TO-BE"]
+    B1["ci-typescript\nsetup-node@v4\ncache: pnpm"]
+    B2["ci-python\nsetup-python@v5\ncache: 'pip'"]
+  end
+
+  A1 -->|T25| B1
+  A2 -->|T28| B2
+```
+
+### release.yml
+
+```mermaid
+graph LR
+  subgraph AS-IS["release.yml — AS-IS"]
+    C1["workflow level\npermissions:\n  contents: write"]
+    C2["job: release\n(inherits write)"]
+    C1 --> C2
+  end
+
+  subgraph TO-BE["release.yml — TO-BE"]
+    D1["workflow level\n(no permissions block)"]
+    D2["job: release\npermissions:\n  contents: write"]
+    D1 --> D2
+  end
+
+  C1 -->|T29| D1
+  C2 -->|T29| D2
+```
+
+---
+
+## 2. Components Affected
+
+| File | Component | Change | Task |
+|------|-----------|--------|------|
+| `.github/workflows/ci.yml` | `ci-typescript` job — `actions/setup-node@v4` step | Add `cache: pnpm` inside `with:` | T25 |
+| `.github/workflows/ci.yml` | `ci-python` job — `actions/setup-python@v5` step | Add `cache: 'pip'` inside `with:` | T28 |
+| `.github/workflows/release.yml` | Workflow-level `permissions` block | Remove from workflow scope | T29 |
+| `.github/workflows/release.yml` | `release` job | Add `permissions: contents: write` at job level | T29 |
+
+No TypeScript source files, Python source files, or test files are touched by
+this group. Changes are confined entirely to GitHub Actions workflow YAML files.
+
+---
+
+## 3. Architectural Decision Records
+
+### ADR-001 — Native action cache vs custom `actions/cache` step
+
+**Status:** Accepted
+
+**Context:**
+Both `actions/setup-node@v4` and `actions/setup-python@v5` expose a built-in
+`cache` parameter that internally delegates to `actions/cache`. An alternative
+approach is to add an explicit `actions/cache` step before the install step,
+giving full control over the cache key expression.
+
+**Decision:**
+Use the native `cache:` parameter of each setup action rather than adding a
+separate `actions/cache` step.
+
+**Rationale:**
+- The native parameter uses the recommended cache key strategy for each
+  ecosystem (pnpm store path derived from `pnpm-lock.yaml` hash; pip cache
+  derived from dependency files).
+- It reduces YAML verbosity and the number of steps per job.
+- It is the officially documented approach for both actions and requires no
+  additional maintenance when action versions are bumped.
+- The only scenario where an explicit `actions/cache` step would be preferred
+  is when a custom restore key strategy or a non-standard cache path is needed.
+  Neither applies here.
+
+**Consequences:**
+- Simpler workflow YAML, easier to review.
+- Cache key logic is opaque (handled internally by the action).
+- If the default cache key strategy ever proves insufficient (e.g., monorepo
+  with multiple lockfiles), an explicit `actions/cache` step can be introduced
+  at that point without conflict.
+
+---
+
+### ADR-002 — Job-level permissions vs workflow-level permissions
+
+**Status:** Accepted
+
+**Context:**
+`release.yml` currently declares `permissions: contents: write` at workflow
+scope. GitHub Actions applies workflow-level permissions to all jobs in the
+workflow. While the file currently contains only one job (`release`), the
+pattern creates a security liability: any job added in the future would inherit
+write access to repository contents by default, even if it does not require it.
+
+**Decision:**
+Move `permissions: contents: write` from the workflow level to the `release` job
+level.
+
+**Rationale:**
+- Follows the GitHub-recommended principle of least privilege for Actions
+  workflows: "Grant only the permissions required, at the narrowest scope."
+- A job-level declaration overrides the workflow-level default for that specific
+  job. With no workflow-level block, the default for all other jobs is
+  `permissions: {}` (no permissions), which is the secure baseline.
+- The functional behaviour of the `release` job is identical: it still receives
+  `contents: write` to push the version bump commit and the git tag.
+- This change future-proofs the workflow: a `publish-npm` job or a
+  `post-release-notification` job added later will not accidentally inherit
+  write access.
+
+**Consequences:**
+- The `release` job behaviour is unchanged.
+- Future jobs in `release.yml` start with no permissions unless explicitly
+  declared — this is the desired default.
+- Reviewers can determine the permission scope of a job by reading only that
+  job's block, without needing to check the workflow header.
+
+---
+
+## 4. Security Considerations
+
+### S-01 — Poisoned cache attack surface
+
+GitHub Actions caches are scoped to a branch and repository by default. A cache
+entry created on `develop` cannot be restored on `master` unless explicitly
+configured with cross-branch restore keys. The native `cache:` parameter uses
+safe, branch-scoped keys, so the risk of a malicious cache entry injected from a
+fork or unrelated branch is low. No additional mitigations are required for this
+group.
+
+### S-02 — Token exposure via overly broad permissions
+
+The current `permissions: contents: write` at workflow level means the
+`GITHUB_TOKEN` used in any step of any job in `release.yml` carries write access
+to repository contents. If a future step calls an external action that reads the
+token from the environment, that token would have broader access than intended.
+Moving to job-level permissions (T29) eliminates this risk for jobs that do not
+need write access.
+
+### S-03 — No secrets introduced
+
+No new secrets or environment variables are added by this group. Existing use of
+`secrets.GITHUB_TOKEN` in `release.yml` is unchanged.
+
+---
+
+## 5. Risk Table
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|------|-----------|--------|-----------|
+| R-01 | pnpm cache miss on first run after T25 | High (expected) | Low — full install still runs, CI passes | Document that cold runs are expected on first execution; subsequent runs benefit from cache |
+| R-02 | pip cache miss if `pyproject.toml` extras change frequently | Medium | Low — pip install still runs, no failure | The `pip` cache key includes dependency files; changes to `pyproject.toml` naturally invalidate the cache |
+| R-03 | T29 breaks `git push` in release job due to missing permissions | Low — change is a structural move, not a removal | High — release pipeline stops producing tags | Validate with a manual workflow dispatch test or by reviewing the job-level permissions block before merging |
+| R-04 | Future job added to `release.yml` fails silently due to default no-permissions baseline | Low — developer must read ADR-002 | Medium — unexpected permission denied error | ADR-002 documents the intent; the error message from GitHub Actions is explicit |

--- a/docs/sdd/ci-cd-hardening/requirements.md
+++ b/docs/sdd/ci-cd-hardening/requirements.md
@@ -1,0 +1,105 @@
+# Requirements — ci-cd-hardening
+
+> Group: T25, T28, T29
+> Last updated: 2026-03-17
+
+---
+
+## 1. Purpose
+
+This document specifies the requirements for hardening the CI/CD pipeline of the
+`playwright-ppia` project. The group addresses three independent but related
+improvements: dependency caching for the TypeScript job (T25), dependency caching
+for the Python job (T28), and permission scoping for the release workflow (T29).
+
+---
+
+## 2. Functional Requirements
+
+### FR-01 — pnpm dependency cache in ci-typescript [MUST]
+
+**UBIQUITOUS:** THE SYSTEM SHALL configure `actions/setup-node@v4` in the
+`ci-typescript` job of `ci.yml` with `cache: pnpm` so that pnpm's package store
+is persisted and restored across CI runs on the same branch.
+
+**Acceptance criteria:**
+- `setup-node@v4` step in `ci-typescript` includes `cache: pnpm`.
+- A warm run (lockfile unchanged) skips the full `pnpm install` network fetch.
+
+---
+
+### FR-02 — pip dependency cache in ci-python [MUST]
+
+**UBIQUITOUS:** THE SYSTEM SHALL configure `actions/setup-python@v5` in the
+`ci-python` job of `ci.yml` with `cache: 'pip'` so that pip's HTTP cache is
+persisted and restored across CI runs on the same branch.
+
+**Acceptance criteria:**
+- `setup-python@v5` step in `ci-python` includes `cache: 'pip'`.
+- A warm run (no dependency changes) restores packages from cache without
+  downloading from PyPI.
+
+---
+
+### FR-03 — Job-scoped permissions in release.yml [MUST]
+
+**UBIQUITOUS:** THE SYSTEM SHALL move the `permissions: contents: write`
+declaration in `release.yml` from the workflow level to the `release` job level,
+so that only the job that requires write access to repository contents holds that
+permission.
+
+**Acceptance criteria:**
+- No `permissions` block exists at the top-level workflow scope in `release.yml`.
+- The `release` job contains `permissions: contents: write`.
+- The workflow continues to push the version bump commit and tag successfully
+  after the change.
+
+---
+
+### FR-04 — CI duration improvement [SHOULD]
+
+**EVENT-DRIVEN:** WHEN a pull request is opened or updated against `develop` or
+`master`, THE SYSTEM SHALL restore cached dependencies for both the TypeScript
+and Python jobs within the normal GitHub Actions cache TTL (7 days), reducing
+average job duration compared to a cold run.
+
+**Note:** No hard SLA is imposed; improvement is expected but not instrumented
+in this group.
+
+---
+
+### FR-05 — No regression on existing CI behaviour [MUST]
+
+**UNWANTED:** IF any change in this group causes an existing passing check
+(lint, typecheck, tests) to fail on a previously passing pull request, THEN THE
+SYSTEM SHALL surface the failure in the CI run so it can be investigated and
+corrected before merging.
+
+---
+
+## 3. Non-Functional Requirements
+
+### NFR-01 — Security: Principle of Least Privilege
+
+The `release.yml` workflow MUST NOT grant `contents: write` at workflow scope.
+Other jobs added to the workflow in the future MUST NOT inherit write access to
+repository contents unless explicitly declared in their own `permissions` block.
+
+### NFR-02 — Performance: Cache hit ratio
+
+The pnpm and pip caches SHALL use the action-native cache keys derived from the
+lockfile (`pnpm-lock.yaml` for pnpm, `requirements` files for pip). This
+maximises hit ratio without additional custom cache configuration.
+
+### NFR-03 — Maintainability: Configuration locality
+
+Cache and permission settings SHALL be declared as close as possible to the step
+or job they govern (i.e., inside `with:` of the setup action, or inside the job
+block), not as global workflow-level variables or secrets, to make intent
+immediately readable during code review.
+
+### NFR-04 — Compatibility: Pinned action versions
+
+All changes SHALL use the action versions already present in the workflow
+(`actions/setup-node@v4`, `actions/setup-python@v5`) and SHALL NOT introduce
+new actions or bump existing ones as a side effect of this group.

--- a/docs/sdd/ci-cd-hardening/tasks.md
+++ b/docs/sdd/ci-cd-hardening/tasks.md
@@ -1,0 +1,183 @@
+# Tasks — ci-cd-hardening
+
+> Group: T25, T28, T29
+> Last updated: 2026-03-17
+
+---
+
+## Task Breakdown
+
+---
+
+### T25 — Add pnpm cache in ci-typescript job
+
+**Size:** S
+**Branch:** `feature/t25_pnpm_cache_ci`
+**File affected:** `.github/workflows/ci.yml`
+
+**Description:**
+Add `cache: pnpm` to the `actions/setup-node@v4` step inside the `ci-typescript`
+job. This enables GitHub Actions' built-in pnpm store caching, keyed on
+`pnpm-lock.yaml`.
+
+**Current state (AS-IS):**
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: 20
+```
+
+**Target state (TO-BE):**
+```yaml
+- uses: actions/setup-node@v4
+  with:
+    node-version: 20
+    cache: pnpm
+```
+
+**Dependencies:** none
+
+**Acceptance criteria:**
+1. The `actions/setup-node@v4` step in the `ci-typescript` job contains
+   `cache: pnpm` in its `with:` block.
+2. A pull request CI run that does not change `pnpm-lock.yaml` restores pnpm's
+   package store from cache (GitHub Actions UI shows "Cache restored" in the
+   setup-node step log).
+
+---
+
+### T28 — Add pip cache in ci-python job
+
+**Size:** S
+**Branch:** `feature/t28_pip_cache_ci`
+**File affected:** `.github/workflows/ci.yml`
+
+**Description:**
+Add `cache: 'pip'` to the `actions/setup-python@v5` step inside the `ci-python`
+job. This enables GitHub Actions' built-in pip caching, keyed on dependency
+files (`pyproject.toml`, `requirements*.txt`).
+
+**Current state (AS-IS):**
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.11"
+```
+
+**Target state (TO-BE):**
+```yaml
+- uses: actions/setup-python@v5
+  with:
+    python-version: "3.11"
+    cache: 'pip'
+```
+
+**Dependencies:** none (T25 and T28 are independent; they touch the same file
+but different jobs)
+
+**Acceptance criteria:**
+1. The `actions/setup-python@v5` step in the `ci-python` job contains
+   `cache: 'pip'` in its `with:` block.
+2. A pull request CI run that does not change `pyproject.toml` or any
+   `requirements*.txt` file restores pip's HTTP cache from the action cache
+   (GitHub Actions UI shows "Cache restored" in the setup-python step log).
+
+---
+
+### T29 — Move permissions to job level in release.yml
+
+**Size:** S
+**Branch:** `feature/t29_job_level_permissions`
+**File affected:** `.github/workflows/release.yml`
+
+**Description:**
+Remove the `permissions: contents: write` block from the workflow level in
+`release.yml` and re-declare it under the `release` job. This limits write
+access to repository contents to the only job that requires it, following the
+principle of least privilege.
+
+**Current state (AS-IS):**
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write   # ← workflow level: applies to ALL jobs
+
+jobs:
+  release:
+    name: Bump version & tag
+    runs-on: ubuntu-latest
+    steps:
+      ...
+```
+
+**Target state (TO-BE):**
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  release:
+    name: Bump version & tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # ← job level: applies only to this job
+    steps:
+      ...
+```
+
+**Dependencies:** none
+
+**Acceptance criteria:**
+1. No `permissions` block exists at the top-level workflow scope in
+   `release.yml`.
+2. The `release` job block contains `permissions: contents: write`.
+3. The release workflow executes successfully after the change: the "Commit and
+   tag" step pushes the version bump commit and the git tag to `master` without
+   a permissions error.
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph LR
+  T25["T25\npnpm cache\nci-typescript\nSize: S"]
+  T28["T28\npip cache\nci-python\nSize: S"]
+  T29["T29\njob-level permissions\nrelease.yml\nSize: S"]
+```
+
+All three tasks are **independent** — they can be implemented and merged in any
+order. T25 and T28 touch different jobs within the same file; T29 touches a
+different file entirely.
+
+---
+
+## Summary by Size
+
+| Size | Count | Tasks |
+|------|-------|-------|
+| S | 3 | T25, T28, T29 |
+| M | 0 | — |
+| L | 0 | — |
+| **Total** | **3** | |
+
+---
+
+## Implementation Notes
+
+- T25 and T28 can be batched into a single PR (`feature/t25_t28_ci_cache`) if
+  the team prefers to keep CI changes together. Each still maps to its own
+  GitHub issue.
+- T29 MUST be tested by triggering the release workflow (push to `master` or
+  manual dispatch) after merging, to confirm the tag push succeeds with
+  job-level permissions only.
+- All three tasks have size S because each change is a one- or two-line YAML
+  addition/move with no logic or test changes required.

--- a/docs/sdd/github-community/design.md
+++ b/docs/sdd/github-community/design.md
@@ -1,0 +1,195 @@
+# Design — github-community
+> SDD Group: T30 + T31
+> Last updated: 2026-03-17
+
+---
+
+## File Structure
+
+```mermaid
+graph TD
+    ROOT[".github/"] --> TEMPLATES["ISSUE_TEMPLATE/"]
+    ROOT --> PR["pull_request_template.md"]
+    TEMPLATES --> BUG["bug_report.md"]
+    TEMPLATES --> FEAT["feature_request.md"]
+    TEMPLATES --> CONFIG["config.yml  (blank issue link)"]
+
+    BUG:::component
+    FEAT:::component
+    PR:::component
+    CONFIG:::helper
+
+    classDef component fill:#0075ca,color:#fff,stroke:#005a9e
+    classDef helper fill:#6b7280,color:#fff,stroke:#4b5563
+```
+
+---
+
+## Components
+
+### bug_report.md
+
+**Responsibility**: capture structured, reproducible bug reports from the
+community with enough context to diagnose issues without back-and-forth.
+
+**Content structure**:
+
+| Section | Type | Notes |
+|---------|------|-------|
+| Description | `textarea` | Brief description of the bug |
+| Steps to reproduce | `textarea` | Numbered list |
+| Expected behaviour | `textarea` | What should happen |
+| Actual behaviour | `textarea` | What actually happens |
+| Environment | `textarea` | Node.js version, OS, `playwright-ppia` version, Playwright version |
+| Error output / logs | `textarea` | Full stack trace or terminal output |
+| Additional context | `textarea` | Screenshots, related issues |
+
+**GitHub front matter**:
+```yaml
+name: Bug Report
+description: Report a reproducible bug
+labels: ["bug"]
+```
+
+**Security note**: the Environment section includes an inline reminder:
+`> Do not include API keys, passwords, or any credentials.`
+
+---
+
+### feature_request.md
+
+**Responsibility**: collect well-defined feature proposals that map back to
+real QA automation use cases, making prioritisation decisions easier for
+maintainers.
+
+**Content structure**:
+
+| Section | Type | Notes |
+|---------|------|-------|
+| Problem statement | `textarea` | What limitation are you hitting? |
+| Proposed solution | `textarea` | Your preferred approach |
+| Alternatives considered | `textarea` | Other options you evaluated |
+| Use case context | `textarea` | Your project type, stack, workflow |
+| Additional context | `textarea` | Links, prior art, mockups |
+
+**GitHub front matter**:
+```yaml
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["feature"]
+```
+
+---
+
+### pull_request_template.md
+
+**Responsibility**: enforce a consistent PR structure that links to an issue,
+describes the change type, and includes a test plan — aligning with the
+project's existing `Closes #N` convention and pre-push hook quality gates.
+
+**Content structure**:
+
+| Section | Type | Notes |
+|---------|------|-------|
+| Summary | bullet list | 1–3 concise bullet points |
+| Type of change | checkbox list | bug fix / new feature / refactor / docs / chore |
+| Test plan | checkbox list | Steps the reviewer should follow to verify |
+| Issue reference | text | `Closes #N` — mandatory |
+
+**No GitHub front matter** (PR templates do not support YAML front matter).
+
+---
+
+### config.yml (ISSUE_TEMPLATE)
+
+**Responsibility**: add a "blank issue" escape hatch and optionally link to
+the project's discussion forum, so contributors are not forced into a template
+for open-ended questions.
+
+```yaml
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/joseguillermomoreu-gif/playwright-ppia/discussions
+    about: Ask questions and discuss ideas
+```
+
+---
+
+## Architecture Decision Records
+
+### ADR-01 — Template language: English
+
+**Status**: Accepted
+
+**Context**: The project's internal files (CLAUDE.md, ARCHITECTURE.md,
+MEMORY.md) are in Spanish. The package is published on npm under the name
+`playwright-ppia` and targets the broader Playwright / QA automation
+community, which is predominantly English-speaking.
+
+**Decision**: All `.github/` community health files are written in English.
+Internal tooling files remain in Spanish.
+
+**Consequences**:
+- Community contributors can engage without a language barrier.
+- Maintainer-facing files (CLAUDE.md, SDD docs) stay in Spanish as the
+  working language of the team.
+- No translation overhead is introduced for the public surface.
+
+**Rejected alternative**: bilingual templates (English + Spanish inline).
+Rejected because it doubles template length without proportional benefit —
+the package audience is international, not primarily Spanish-speaking.
+
+---
+
+### ADR-02 — Issue template format: YAML front matter + Markdown body
+
+**Status**: Accepted
+
+**Context**: GitHub supports two formats for issue templates:
+1. Legacy: plain Markdown files in `.github/ISSUE_TEMPLATE/`
+2. Modern: GitHub Issue Forms (YAML-only, with `type: input/textarea/dropdown`)
+
+**Decision**: Use the **legacy Markdown format** with YAML front matter
+(`name`, `description`, `labels`).
+
+**Rationale**:
+- Issue Forms require a full YAML schema and are more brittle to maintain.
+- The Markdown format renders predictably across GitHub's web UI, API,
+  and third-party tools.
+- The fields in bug reports and feature requests are all free-text — there
+  is no benefit from dropdowns or validations at this stage.
+- Easier for community contributors to preview and edit locally.
+
+**Consequences**:
+- Template fields are `<!-- comment -->` placeholders, not enforced inputs.
+- If structured data extraction is needed in the future, migration to Issue
+  Forms is straightforward.
+
+**Rejected alternative**: GitHub Issue Forms (YAML).
+Rejected because the added complexity and fragility is not justified for
+the current contributor volume.
+
+---
+
+## Security Considerations
+
+| Surface | Risk | Mitigation |
+|---------|------|-----------|
+| Bug report — Environment section | Contributor pastes `ppia.yaml` with credentials or API keys in plain text | Inline warning in the template body: `Do not include API keys, passwords, or credentials.` |
+| Bug report — Error output section | Stack traces may contain internal paths, session IDs, or tokens | Inline note: `Redact any sensitive values before pasting.` |
+| PR template — Test plan | No sensitive data expected | No specific mitigation needed |
+
+The templates do not collect or store data themselves. All content is
+submitted directly to GitHub as issue/PR bodies, governed by GitHub's
+own security and privacy policies.
+
+---
+
+## Risk Table
+
+| # | Risk | Probability | Impact | Mitigation |
+|---|------|-------------|--------|------------|
+| R1 | Contributors ignore templates and open blank issues anyway | Medium | Low | `blank_issues_enabled: true` in `config.yml` channels these; label triage handles the rest |
+| R2 | Template becomes stale as the project evolves (new config fields, new CLI commands) | Medium | Medium | Templates reference the project generically, not specific CLI flags; updates needed only when the bug reproduction model changes fundamentally |
+| R3 | PR template `Closes #N` placeholder is deleted by contributors | High | Low | Convention is enforced by maintainer review, not automation; the placeholder is a prompt, not a validation |

--- a/docs/sdd/github-community/requirements.md
+++ b/docs/sdd/github-community/requirements.md
@@ -1,0 +1,74 @@
+# Requirements — github-community
+> SDD Group: T30 + T31
+> Last updated: 2026-03-17
+
+---
+
+## Overview
+
+This group covers the creation of GitHub community health files for the
+`playwright-ppia` npm package repository. These files guide external contributors
+when opening issues and pull requests, ensuring consistent, actionable reports
+and reducing maintainer triage overhead.
+
+---
+
+## Functional Requirements (EARS format)
+
+### FR-01 — Bug report template (MUST)
+
+**When** a user clicks "New Issue" on the repository,
+**the system shall** present a `Bug Report` template that collects:
+reproduction steps, expected vs actual behaviour, environment details
+(Node.js version, OS, `playwright-ppia` version), and the full error output.
+
+### FR-02 — Feature request template (MUST)
+
+**When** a user clicks "New Issue" on the repository,
+**the system shall** present a `Feature Request` template that collects:
+a problem statement, a proposed solution, alternatives considered,
+and the use case context from the user's project.
+
+### FR-03 — Pull request template (MUST)
+
+**When** a contributor opens a Pull Request,
+**the system shall** pre-fill the PR body with a structured template that
+includes: a summary section, a type-of-change checklist, a test plan
+checklist, and the `Closes #N` trailer for automatic issue linking.
+
+### FR-04 — Blank issue fallback (SHOULD)
+
+**Where** neither bug report nor feature request fits,
+**the system should** provide an option to open a blank issue so that
+discussion-type threads are not blocked by the template mechanism.
+
+---
+
+## Non-Functional Requirements
+
+### NFR-01 — Language consistency
+
+All community templates MUST be written in **English**.
+Rationale: the package is published on npm and targets an international
+Playwright / QA automation audience. Internal project tooling (CLAUDE.md,
+ARCHITECTURE.md) is in Spanish and is not part of the public-facing surface.
+
+### NFR-02 — Maintainability
+
+Templates MUST use GitHub-flavoured Markdown only (no HTML, no YAML front
+matter beyond the `name`/`description`/`labels` fields recognised by GitHub).
+This ensures they render correctly without additional tooling and remain easy
+to update in a text editor.
+
+### NFR-03 — Security
+
+Templates MUST NOT request API keys, passwords, `ppia.yaml` credentials, or
+any other sensitive value in plain text.
+The bug report template MUST include a visible reminder to redact credentials
+before submitting environment details.
+
+### NFR-04 — Traceability
+
+The pull request template MUST include a `Closes #N` placeholder to enforce
+the automatic issue-closing convention already established in `CLAUDE.md`
+(§ Cierre automático de issues).

--- a/docs/sdd/github-community/tasks.md
+++ b/docs/sdd/github-community/tasks.md
@@ -1,0 +1,120 @@
+# Tasks — github-community
+> SDD Group: T30 + T31
+> Last updated: 2026-03-17
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph LR
+    T30["T30 — ISSUE_TEMPLATE/\n(bug_report + feature_request + config.yml)"]
+    T31["T31 — pull_request_template.md"]
+
+    T30 --> T31
+```
+
+T31 has no technical dependency on T30, but T30 is conventionally completed
+first so that the PR used to deliver T31 can itself benefit from the PR
+template being in place.
+
+---
+
+## T30 — Create .github/ISSUE_TEMPLATE/
+
+**GitHub issue**: [#59](https://github.com/joseguillermomoreu-gif/playwright-ppia/issues/59)
+**Label**: `docs`
+**Size**: XS
+**Branch**: `feature/t30_github_issue_templates`
+**Base**: `origin/develop`
+
+### Description
+
+Create the `.github/ISSUE_TEMPLATE/` directory with three files:
+- `bug_report.md` — structured bug report template
+- `feature_request.md` — feature proposal template
+- `config.yml` — blank issue opt-in and Discussions link
+
+### Files affected
+
+| File | Action |
+|------|--------|
+| `.github/ISSUE_TEMPLATE/bug_report.md` | Create |
+| `.github/ISSUE_TEMPLATE/feature_request.md` | Create |
+| `.github/ISSUE_TEMPLATE/config.yml` | Create |
+
+### Acceptance criteria
+
+1. When a contributor clicks "New Issue" on the repository, GitHub presents
+   two template options — "Bug Report" and "Feature Request" — plus a
+   "blank issue" option.
+2. Each template pre-fills the issue body with the sections defined in
+   `design.md` (Description, Steps to Reproduce, Environment, etc.),
+   and automatically applies the corresponding label (`bug` or `feature`).
+3. The bug report template contains a visible security reminder to redact
+   credentials before submitting.
+4. `config.yml` enables blank issues and includes a link to GitHub
+   Discussions.
+
+### Implementation notes
+
+- YAML front matter uses only `name`, `description`, `labels` — no Issue
+  Forms schema (see ADR-02).
+- All content in English (see ADR-01).
+- Template sections use HTML comment placeholders (`<!-- ... -->`), not
+  hard-coded example text that contributors would have to delete.
+
+---
+
+## T31 — Create .github/pull_request_template.md
+
+**GitHub issue**: [#60](https://github.com/joseguillermomoreu-gif/playwright-ppia/issues/60)
+**Label**: `docs`
+**Size**: XS
+**Branch**: `feature/t31_github_pr_template`
+**Base**: `origin/develop`
+**Depends on**: T30 (by convention — T30 should be merged first)
+
+### Description
+
+Create `.github/pull_request_template.md`, which GitHub auto-fills into the
+PR body for every new pull request opened against the repository.
+
+### Files affected
+
+| File | Action |
+|------|--------|
+| `.github/pull_request_template.md` | Create |
+
+### Acceptance criteria
+
+1. When a contributor opens a new PR, GitHub pre-fills the body with the
+   template sections: Summary, Type of Change (checkbox list), Test Plan
+   (checkbox list), and an issue reference line with `Closes #N`.
+2. The template does not include a YAML front matter block (PR templates
+   do not support it; adding one would render it as raw text in the PR body).
+3. The `Closes #N` line is present and matches the automatic issue-closing
+   convention documented in `CLAUDE.md`.
+
+### Implementation notes
+
+- File location must be exactly `.github/pull_request_template.md`
+  (case-sensitive; GitHub does not recognise alternative paths).
+- All content in English (see ADR-01).
+- Checkboxes use `- [ ]` syntax so they render as interactive checkboxes
+  in GitHub's PR UI.
+
+---
+
+## Summary by size
+
+| Size | Count | Tasks |
+|------|-------|-------|
+| XS | 2 | T30, T31 |
+| S | 0 | — |
+| M | 0 | — |
+| L | 0 | — |
+
+Both tasks are **XS** — they involve only Markdown file creation with no
+code changes, no test suite changes, and no CI/CD impact.
+Total estimated effort: < 1 hour combined.

--- a/docs/sdd/release-readiness/design.md
+++ b/docs/sdd/release-readiness/design.md
@@ -1,0 +1,249 @@
+# Design — Release Readiness (T21 / T22 / T23)
+
+> Group: `release-readiness`
+> Tasks: T21 (Documentation), T22 (npm publish), T23 (Example project)
+
+---
+
+## 1. Release Pipeline — Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant GH as GitHub (master)
+    participant CI as release.yml
+    participant NPM as npmjs.com
+
+    Dev->>GH: git push origin master
+    GH->>CI: trigger: push to master
+
+    CI->>CI: checkout (fetch-depth: 0)
+    CI->>CI: pnpm/action-setup@v4
+    CI->>CI: setup-node@v4<br/>(registry-url: registry.npmjs.org)
+
+    CI->>CI: Determine version bump<br/>(patch / minor / major from commits)
+    CI->>CI: npm version <bump> --no-git-tag-version<br/>(updates packages/core/package.json)
+
+    CI->>CI: git add packages/core/package.json
+    CI->>GH: git commit + git tag vX.Y.Z
+    CI->>GH: git push origin master --follow-tags
+
+    Note over CI: NEW in T22 ↓
+
+    CI->>CI: pnpm build<br/>(compiles dist/ from src/)
+    CI->>NPM: npm publish --access public<br/>(NODE_AUTH_TOKEN = secrets.NPM_TOKEN)
+    NPM-->>CI: 200 OK / version already exists → fail
+
+    CI-->>Dev: workflow success / failure notification
+```
+
+---
+
+## 2. Components
+
+### 2.1 `packages/core/README.md` (NEW — T21)
+
+**Purpose**: Public-facing documentation shown on the npm package page and in the GitHub directory.
+
+**Structure**:
+```
+packages/core/README.md
+├── Header: name + badge (npm version, license)
+├── Short description
+├── Prerequisites (Node >=18, Python >=3.10, API key)
+├── Installation
+├── Quick Start (ppia init → ppia generate)
+├── CLI Reference (all subcommands: generate, run, setup, suite, docs, compare)
+├── Configuration (ppia.yaml overview)
+├── How It Works (TypeScript + Python AI Service architecture note)
+└── Contributing (link to root CONTRIBUTING.md)
+```
+
+**Language**: English (see ADR-03).
+
+**Relationship to existing docs**: The root `README.md` already exists and covers the project broadly. `packages/core/README.md` is package-scoped and npm-oriented. They do not duplicate; the root README links to the package README for API/CLI details.
+
+---
+
+### 2.2 `CONTRIBUTING.md` (NEW — T21)
+
+**Purpose**: Onboarding guide for contributors; referenced from `packages/core/README.md`.
+
+**Location**: Repository root (`/CONTRIBUTING.md`).
+
+**Structure**:
+```
+CONTRIBUTING.md
+├── Prerequisites (Node 20+, pnpm 9+, Python 3.10+)
+├── Local setup
+│   ├── pnpm install (from root)
+│   ├── Python venv + pip install -e ".[dev]"
+│   └── Environment variables (.env.example reference)
+├── Repository layout
+│   ├── packages/core/src/ — TypeScript
+│   ├── packages/core/python/ — Python AI Service
+│   └── examples/ — usage examples
+├── Quality checks
+│   ├── TypeScript: pnpm lint / pnpm typecheck / pnpm test
+│   └── Python: ruff check / mypy --strict / pytest
+├── Branch & commit conventions (Conventional Commits)
+├── PR workflow (feature/tN_desc → develop → master)
+└── Release process (automated via release.yml)
+```
+
+---
+
+### 2.3 `.github/workflows/release.yml` (MODIFIED — T22)
+
+**Current state**: The final step is a placeholder `echo` with no actual publish.
+
+**Changes required**:
+
+1. Add `registry-url` to the existing `setup-node@v4` step:
+   ```yaml
+   - uses: actions/setup-node@v4
+     with:
+       node-version: 20
+       cache: pnpm
+       registry-url: https://registry.npmjs.org
+   ```
+
+2. Replace the placeholder step with two real steps:
+   ```yaml
+   - name: Build
+     working-directory: packages/core
+     run: pnpm build
+
+   - name: Publish to npm
+     working-directory: packages/core
+     run: npm publish --access public
+     env:
+       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+   ```
+
+3. No other steps change. The version bump, commit, and tag steps remain identical.
+
+**Secret required**: `NPM_TOKEN` must be added to the repository's GitHub Actions secrets by a repository administrator before merging T22.
+
+---
+
+### 2.4 `examples/basic-project/` (NEW — T23)
+
+**Purpose**: A minimal, copy-paste-ready project showing the full `ppia init` → `ppia generate` workflow.
+
+**Directory structure**:
+```
+examples/basic-project/
+├── package.json          # devDependency: playwright-ppia ^0.x.x
+├── ppia.yaml             # pre-filled example config (no real API key)
+├── README.md             # step-by-step walkthrough
+└── .gitignore            # ignores .ppia/, output/, node_modules/
+```
+
+**`package.json` content**:
+```json
+{
+  "name": "ppia-basic-example",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "ppia": "ppia"
+  },
+  "devDependencies": {
+    "playwright-ppia": "^0.1.0"
+  }
+}
+```
+
+**`ppia.yaml` content** (illustrative — no real credentials):
+```yaml
+users:
+  - name: demo
+    model: openai/gpt-4o-mini
+    api_key: "YOUR_OPENAI_API_KEY"
+base_url: "https://example.com"
+output_dir: output/
+```
+
+**`README.md` walkthrough**:
+1. `npm install` — installs `playwright-ppia`
+2. Edit `ppia.yaml` — add real API key and base URL
+3. `npx ppia generate "Login with valid credentials"`
+4. Inspect `output/` for the generated spec
+
+---
+
+## 3. Architectural Decision Records
+
+### ADR-01 — npm publish scope: public unscoped package
+
+**Status**: Accepted
+
+**Context**: The package name `playwright-ppia` is currently unscoped. We could publish as `@ppia/core` (scoped) or keep it unscoped.
+
+**Decision**: Keep `playwright-ppia` as an unscoped public package.
+
+**Consequences**:
+- `npm publish --access public` is needed only once for a new unscoped package; subsequent publishes default to public.
+- No npm organization setup required.
+- The name `playwright-ppia` is descriptive and searchable (`playwright` prefix aids discoverability).
+- Scoped packages (`@ppia/*`) would require an npm organization named `ppia` and would complicate the install UX (`npm install --save-dev @ppia/core` vs `npm install --save-dev playwright-ppia`).
+
+**Rejected alternative**: `@playwright-ppia/core` — overly verbose and provides no benefit at this stage.
+
+---
+
+### ADR-02 — Example project structure: static files, no live app dependency
+
+**Status**: Accepted
+
+**Context**: An example project could be (a) runnable against a live URL, (b) runnable against a local mock server, or (c) purely illustrative static files with no runtime dependency.
+
+**Decision**: The example at `examples/basic-project/` is static documentation with no runtime dependency. It shows realistic file contents and a step-by-step README, but does not ship a mock server or require any running application.
+
+**Consequences**:
+- Zero CI complexity: no need to spin up a test server in GitHub Actions to validate the example.
+- Users understand the workflow from reading rather than running.
+- Downside: the example cannot be automatically tested end-to-end. This is accepted because a runnable E2E example belongs to a future "demo project" task, not the release-readiness group.
+
+**Rejected alternative**: Mock server (e.g., `json-server`) embedded in `examples/basic-project/` — deferred to a future task.
+
+---
+
+### ADR-03 — Documentation language: English only
+
+**Status**: Accepted
+
+**Context**: The internal codebase comments, commit messages, and existing `docs/ARCHITECTURE.md` are in Spanish. The npm package will be published publicly and consumed internationally.
+
+**Decision**: All public-facing documentation (`packages/core/README.md`, `CONTRIBUTING.md`, `examples/basic-project/README.md`) SHALL be written in English. Internal documents (`docs/ARCHITECTURE.md`, issue bodies, PR descriptions) may remain in Spanish.
+
+**Consequences**:
+- npm page and GitHub README are accessible to the global community.
+- No translation maintenance burden: internal and external docs are clearly separated by language.
+- No existing internal docs need to be rewritten.
+
+---
+
+## 4. Security Considerations
+
+| Concern | Mitigation |
+|---|---|
+| `NPM_TOKEN` exposure in logs | Used only as `NODE_AUTH_TOKEN` env var on the publish step; no `echo`, no `--verbose` npm flag |
+| `NPM_TOKEN` committed to repo | Never written to `.npmrc` or any committed file; stored exclusively as a GitHub Actions secret |
+| Accidental publish of source files | `files` field in `package.json` is already set to `["dist/", "python/"]`; validated before enabling real publish |
+| `.env` files bundled in npm artifact | `.env*` is not in `dist/` or `python/`; no additional `.npmignore` needed given the `files` whitelist |
+| Token scope | The `NPM_TOKEN` used should be an Automation token (not a Classic token) scoped to publish only for `playwright-ppia` |
+| Re-runs publishing duplicate versions | `npm publish` fails with `E403` if version already exists; the step will surface this error and not silently overwrite |
+
+---
+
+## 5. Risk Table
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R-01 | `NPM_TOKEN` secret not provisioned before T22 merge | Medium | High — publish step fails on first real release | Document secret setup requirement in T22 PR description; block merge until administrator confirms secret is set |
+| R-02 | `dist/` not generated before publish (missing `pnpm build` step) | Low | High — npm artifact contains no compiled code | Explicit `pnpm build` step added immediately before `npm publish` in release.yml |
+| R-03 | Package name `playwright-ppia` already claimed on npm | Low | High — publish fails with 403 | Verify name availability on npmjs.com before merging T22 (name was available at time of writing) |
+| R-04 | `python/` directory exceeds npm artifact size limits or surprises users | Low | Medium — large install size, confusing for JS-only users | Document in `packages/core/README.md` that Python files are bundled and why; consider size badge |
+| R-05 | Example project's `ppia.yaml` misleads users into using wrong model names | Low | Low — config error at runtime, not security risk | Add inline comments in `ppia.yaml` example explaining each field; link to docs |

--- a/docs/sdd/release-readiness/requirements.md
+++ b/docs/sdd/release-readiness/requirements.md
@@ -1,0 +1,129 @@
+# Requirements — Release Readiness (T21 / T22 / T23)
+
+> Group: `release-readiness`
+> Tasks: T21 (Documentation), T22 (npm publish), T23 (Example project)
+> Format: EARS (Easy Approach to Requirements Syntax)
+
+---
+
+## Functional Requirements
+
+### FR-01 — Public README for packages/core
+
+**WHEN** a developer or potential user visits the `playwright-ppia` npm package page or the `packages/core/` directory on GitHub,
+**THE SYSTEM SHALL** present a `README.md` that includes:
+- Framework description and value proposition
+- Installation instructions (`npm install --save-dev playwright-ppia`)
+- Quick Start section covering `ppia init` and `ppia generate`
+- Description of all CLI subcommands (`generate`, `run`, `setup`, `suite`, `docs`, `compare`)
+- Prerequisites (Node >=18, Python >=3.10, an OpenAI or Anthropic API key)
+- Link to the root `CONTRIBUTING.md`
+
+**Rationale**: The current `packages/core/` directory has no README; the npm page will be blank without one.
+
+---
+
+### FR-02 — Contributor guide (CONTRIBUTING.md)
+
+**WHEN** a contributor opens a pull request or wants to set up a local development environment,
+**THE SYSTEM SHALL** provide a `CONTRIBUTING.md` at the repository root that covers:
+- Repository structure (monorepo layout, `packages/core/`, `packages/core/python/`)
+- Local setup steps (pnpm install, Python venv, environment variables)
+- How to run TypeScript quality checks (`pnpm lint`, `pnpm typecheck`, `pnpm test`)
+- How to run Python quality checks (`ruff check`, `mypy --strict`, `pytest`)
+- Branch naming convention and PR workflow
+- Commit message convention (Conventional Commits)
+
+**Rationale**: No `CONTRIBUTING.md` exists in the repository root.
+
+---
+
+### FR-03 — Real npm publish in release pipeline
+
+**WHEN** a commit is pushed to `master` and the `release.yml` workflow reaches the publish step,
+**THE SYSTEM SHALL** execute `npm publish --access public` from `packages/core/` using the `NPM_TOKEN` secret stored in GitHub Actions,
+**INSTEAD OF** the current placeholder `echo` command.
+
+The publish step SHALL:
+- Run `pnpm build` before publishing to ensure `dist/` is up to date
+- Use `NODE_AUTH_TOKEN` environment variable populated from `secrets.NPM_TOKEN`
+- Set `registry-url: https://registry.npmjs.org` on the `setup-node` action
+- Publish only after the version bump and tag have been committed and pushed
+
+**Rationale**: `release.yml` contains `echo "npm publish will be enabled in T22"` — no actual publish occurs today.
+
+---
+
+### FR-04 — `files` field correctness in packages/core/package.json
+
+**WHEN** the package is published to npm,
+**THE SYSTEM SHALL** include exactly the following in the published artifact:
+- `dist/` — compiled TypeScript output
+- `python/` — Python AI service source (bundled with the npm package)
+
+**AND SHALL NOT** include `src/`, `node_modules/`, test files, or any file matching `.env*`.
+
+**Rationale**: The `files` field already exists (`["dist/", "python/"]`) but must be validated against the actual build output before enabling real publishing.
+
+---
+
+### FR-05 — NPM_TOKEN secret provisioning
+
+**WHEN** a repository administrator sets up the project for automated publishing,
+**THE SYSTEM SHALL** require that an `NPM_TOKEN` secret with publish rights is registered in the GitHub repository's Actions secrets under the exact key `NPM_TOKEN`.
+
+The `release.yml` workflow SHALL fail with a clear error (not silently skip) if the secret is absent or empty.
+
+**Rationale**: Without the secret being explicitly provisioned, the publish step would fail with an opaque authentication error.
+
+---
+
+### FR-06 — Example project (examples/basic-project/)
+
+**WHEN** a new user wants to understand how to integrate `playwright-ppia` into a project from scratch,
+**THE SYSTEM SHALL** provide a self-contained example under `examples/basic-project/` that demonstrates:
+- Running `ppia init` to generate `ppia.yaml`
+- Running `ppia generate` with a natural language description
+- The resulting directory structure (`.ppia/`, `output/`)
+- A minimal `package.json` that installs `playwright-ppia` as a dev dependency
+
+The example SHALL NOT require any running application or live URL to be read as documentation.
+
+**Rationale**: No example project exists today; new users have no reference beyond the root README.
+
+---
+
+## Non-Functional Requirements
+
+### NFR-01 — Security: NPM_TOKEN handling
+
+The `NPM_TOKEN` secret SHALL:
+- Never be printed to GitHub Actions logs (no `echo $NPM_TOKEN`, no `--verbose` npm flags that expose it)
+- Be consumed exclusively via the `NODE_AUTH_TOKEN` environment variable on the publish step
+- Not be stored in any committed file (`.npmrc`, `package.json`, workflow files)
+
+A `.npmrc` file SHALL NOT be committed to the repository; authentication SHALL be handled solely through the GitHub Actions environment.
+
+---
+
+### NFR-02 — Maintainability: documentation stays current
+
+The `packages/core/README.md` and root `CONTRIBUTING.md` SHALL be written so that:
+- CLI subcommand list is the single source of truth (cross-referenced from `src/cli/index.ts`)
+- Adding a new subcommand requires updating only `README.md` — no duplication across multiple doc files
+- The example project in `examples/basic-project/` uses `playwright-ppia` as a versioned dev dependency (`"playwright-ppia": "^0.x.x"`) so it tracks npm releases naturally
+
+---
+
+### NFR-03 — Idempotency: release pipeline
+
+The `release.yml` publish step SHALL be idempotent with respect to already-published versions: if the version tag already exists on npm (e.g., due to a re-run), the step SHALL exit with a non-zero code and surface a human-readable error rather than silently overwrite the existing version.
+
+---
+
+## Out of Scope
+
+- Scoped npm package name (e.g., `@ppia/core`) — decided against in ADR-01 (see `design.md`)
+- Automated changelog generation
+- CDN / unpkg distribution
+- Documentation site (separate future task)

--- a/docs/sdd/release-readiness/tasks.md
+++ b/docs/sdd/release-readiness/tasks.md
@@ -1,0 +1,160 @@
+# Tasks — Release Readiness (T21 / T22 / T23)
+
+> Group: `release-readiness`
+> All tasks: size M
+
+---
+
+## T21 — Documentation for contributors + public README
+
+**GitHub Issue title**: `[T21] Add packages/core README and root CONTRIBUTING.md`
+**Label**: `docs`
+**Size**: M
+**Depends on**: — (no dependencies)
+**Blocks**: T22 (README must exist before the npm page goes live)
+
+### What
+
+Create two new documentation files:
+1. `packages/core/README.md` — public, English, shown on the npm package page
+2. `CONTRIBUTING.md` (repository root) — contributor onboarding guide
+
+### Acceptance Criteria
+
+- [ ] `packages/core/README.md` exists and covers: description, prerequisites, installation, quick start (`ppia init` + `ppia generate`), all CLI subcommands, `ppia.yaml` overview, link to `CONTRIBUTING.md`
+- [ ] `CONTRIBUTING.md` exists at repo root and covers: prerequisites, local setup (TypeScript + Python), quality check commands, branch/commit conventions, PR workflow
+- [ ] Both files are written in English
+- [ ] No content is duplicated between `packages/core/README.md` and the root `README.md`
+- [ ] `packages/core/README.md` is referenced/linked from the root `README.md`
+
+### Files affected
+
+```
+packages/core/README.md         (NEW)
+CONTRIBUTING.md                 (NEW)
+README.md                       (MODIFIED — add link to packages/core/README.md)
+```
+
+### Estimated effort
+
+~2–3h (writing + review)
+
+---
+
+## T22 — Enable real npm publish in release.yml
+
+**GitHub Issue title**: `[T22] Enable npm publish in release pipeline`
+**Label**: `chore`
+**Size**: M
+**Depends on**: T21 (README must exist before first publish)
+**Blocks**: T23 (example project pins a real published version)
+
+### What
+
+Replace the placeholder `echo` step in `.github/workflows/release.yml` with a real `npm publish --access public` step authenticated via `NPM_TOKEN`.
+
+### Acceptance Criteria
+
+- [ ] `setup-node@v4` step in `release.yml` has `registry-url: https://registry.npmjs.org`
+- [ ] A `pnpm build` step runs before `npm publish`
+- [ ] `npm publish --access public` runs with `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`
+- [ ] The placeholder `echo` step is removed
+- [ ] `NPM_TOKEN` secret is provisioned in GitHub Actions secrets by a repository administrator (verified before merge)
+- [ ] `packages/core/package.json` `files` field is validated: only `dist/` and `python/` are included
+- [ ] First real publish after merge produces a visible version on npmjs.com
+- [ ] `NODE_AUTH_TOKEN` is not printed in any log line
+
+### Pre-merge checklist (manual)
+
+- [ ] Verify `playwright-ppia` name is available on npmjs.com (or already owned by the project)
+- [ ] Confirm `NPM_TOKEN` secret is set in repository Settings → Secrets → Actions
+- [ ] Run `pnpm build` locally and confirm `dist/` is populated correctly
+- [ ] Run `npm pack --dry-run` from `packages/core/` and review the file list
+
+### Files affected
+
+```
+.github/workflows/release.yml   (MODIFIED — replace placeholder step)
+```
+
+### Estimated effort
+
+~1–2h (implementation + manual verification)
+
+---
+
+## T23 — Example project (examples/basic-project/)
+
+**GitHub Issue title**: `[T23] Add basic example project showing ppia init and generate`
+**Label**: `docs`
+**Size**: M
+**Depends on**: T22 (example pins a real npm version; should not reference an unpublished package)
+
+### What
+
+Create a self-contained example under `examples/basic-project/` that documents the full onboarding flow from zero to first generated test.
+
+### Acceptance Criteria
+
+- [ ] `examples/basic-project/package.json` exists with `playwright-ppia` as a dev dependency (version matching the latest published release)
+- [ ] `examples/basic-project/ppia.yaml` exists with realistic but clearly non-functional placeholder values (e.g., `api_key: "YOUR_OPENAI_API_KEY"`)
+- [ ] `examples/basic-project/README.md` exists and walks through: install → edit ppia.yaml → `ppia generate` → inspect output
+- [ ] `examples/basic-project/.gitignore` ignores `node_modules/`, `.ppia/`, `output/`
+- [ ] The example requires no running application or external server to be read and understood
+- [ ] Root `README.md` links to `examples/basic-project/` as the quickstart reference
+
+### Files affected
+
+```
+examples/basic-project/package.json     (NEW)
+examples/basic-project/ppia.yaml        (NEW)
+examples/basic-project/README.md        (NEW)
+examples/basic-project/.gitignore       (NEW)
+README.md                               (MODIFIED — add link to example)
+```
+
+### Estimated effort
+
+~2–3h (writing + review)
+
+---
+
+## Dependency Graph
+
+```mermaid
+graph TD
+    T21["T21 — Documentation<br/>(packages/core README + CONTRIBUTING.md)"]
+    T22["T22 — npm publish<br/>(enable real publish in release.yml)"]
+    T23["T23 — Example project<br/>(examples/basic-project/)"]
+
+    T21 -->|"README must exist<br/>before npm page goes live"| T22
+    T22 -->|"real version must exist<br/>before example can pin it"| T23
+
+    style T21 fill:#d4edda,stroke:#28a745,color:#000
+    style T22 fill:#fff3cd,stroke:#ffc107,color:#000
+    style T23 fill:#cce5ff,stroke:#004085,color:#000
+```
+
+---
+
+## Summary by size
+
+| Size | Count | Tasks |
+|------|-------|-------|
+| M | 3 | T21, T22, T23 |
+| **Total** | **3** | |
+
+### Recommended implementation order
+
+1. **T21** — Write documentation first so the npm page is not blank on first publish
+2. **T22** — Enable real publish once README is merged; provision `NPM_TOKEN` secret before merging
+3. **T23** — Create example project after first version is live on npm so the pinned version is real
+
+### Critical path
+
+```
+T21 (2–3h) → T22 (1–2h) → T23 (2–3h)
+Total: ~5–8h sequential
+```
+
+All three tasks are sequential (no parallelisation possible due to dependencies). Total elapsed time is bounded by the critical path.


### PR DESCRIPTION
## Summary

- Añade 12 ficheros SDD (requirements + design + tasks) agrupados en 4 épicas
- **ci-cd-hardening**: T25 (pnpm cache) · T28 (pip cache) · T29 (job-level permissions)
- **github-community**: T30 (issue templates) · T31 (PR template)
- **release-readiness**: T21 (README/CONTRIBUTING) · T22 (npm publish) · T23 (example + NPM_TOKEN)
- **ai-service-runtime**: T24.1–T24.5 (health endpoint · pricing · cost estimator · StartupChecker · display)

## Test plan

- [ ] Revisar que los 4 directorios `docs/sdd/*/` existen con sus 3 ficheros
- [ ] Verificar que los diagramas Mermaid renderizan correctamente en GitHub
- [ ] Confirmar que los criterios de aceptación en `tasks.md` están alineados con los issues de GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)