### PR TITLE
chore(ci): add pnpm and pip dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -54,6 +55,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

- **T25**: Add `cache: pnpm` to `actions/setup-node@v4` in the `ci-typescript` job
- **T28**: Add `cache: 'pip'` to `actions/setup-python@v5` in the `ci-python` job

Both changes use the native cache parameter of each setup action (ADR-001: preferred over a custom `actions/cache` step). Cache keys are derived from lockfiles automatically.

## Test plan

- [ ] Verify `setup-node@v4` step in `ci-typescript` has `cache: pnpm`
- [ ] Verify `setup-python@v5` step in `ci-python` has `cache: 'pip'`
- [ ] CI run passes without regressions
- [ ] Subsequent CI run on same branch shows "Cache restored" in setup steps

Closes #25
Closes #28