### PR TITLE
chore(ci): move permissions to job level in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches: [master]
 
-permissions:
-  contents: write
-
 jobs:
   release:
     name: Bump version & tag
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- Move `permissions: contents: write` from workflow-level to `release` job level in `release.yml`
- Follows the principle of least privilege: only the job that needs write access holds it
- Future jobs added to `release.yml` will start with no permissions unless explicitly declared

## Test plan

- [ ] Verify no `permissions` block exists at workflow scope in `release.yml`
- [ ] Verify `release` job has `permissions: contents: write`
- [ ] Release workflow executes successfully after merge (version bump + tag push)

Closes #29