### PR TITLE
docs(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+description: Report a reproducible bug
+labels: ["bug"]
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+<!--
+1. Install `playwright-ppia`
+2. Run `ppia generate "..."`
+3. Observe the error
+-->
+
+## Expected Behaviour
+
+<!-- What you expected to happen. -->
+
+## Actual Behaviour
+
+<!-- What actually happened. -->
+
+## Environment
+
+<!--
+- `playwright-ppia` version:
+- Node.js version:
+- Python version:
+- Operating system:
+- Playwright version:
+
+> Do not include API keys, passwords, or any credentials.
+> Redact any sensitive values before pasting.
+-->
+
+## Error Output / Logs
+
+<!--
+Paste the full stack trace or terminal output here.
+Redact any sensitive values before pasting.
+-->
+
+## Additional Context
+
+<!-- Screenshots, related issues, or any other context. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/joseguillermomoreu-gif/playwright-ppia/discussions
+    about: Ask questions and discuss ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+description: Propose a new feature or enhancement
+labels: ["feature"]
+---
+
+## Problem Statement
+
+<!-- What limitation or pain point are you hitting? -->
+
+## Proposed Solution
+
+<!-- Your preferred approach to solve the problem. -->
+
+## Alternatives Considered
+
+<!-- Other options you evaluated and why you ruled them out. -->
+
+## Use Case Context
+
+<!-- Your project type, tech stack, or workflow — helps us understand the real need. -->
+
+## Additional Context
+
+<!-- Links, prior art, mockups, or any other relevant context. -->


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/bug_report.md` with structured bug report template (labels: `bug`)
- Add `.github/ISSUE_TEMPLATE/feature_request.md` with feature proposal template (labels: `feature`)
- Add `.github/ISSUE_TEMPLATE/config.yml` enabling blank issues and linking to GitHub Discussions

All templates use HTML comment placeholders and are written in English (ADR-01).
Inline security reminders in bug report: do not paste API keys or credentials.

## Test plan

- [ ] Clicking "New Issue" on the repo shows two template options: Bug Report and Feature Request
- [ ] Each template pre-fills sections with `<!-- comment -->` placeholders
- [ ] Corresponding label (`bug` / `feature`) is applied automatically
- [ ] Blank issue option is available

Closes #59