### PR TITLE
docs(github): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!--
+1–3 concise bullet points describing what this PR does.
+-->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Chore / tooling
+
+## Test Plan
+
+<!--
+Steps the reviewer should follow to verify this change works correctly.
+-->
+
+- [ ]
+- [ ]
+
+## Issue Reference
+
+Closes #N


### PR DESCRIPTION
## Summary

- Add `.github/pull_request_template.md` auto-filled by GitHub for every new PR
- Sections: Summary (bullet points), Type of Change (checkboxes), Test Plan (checkboxes), `Closes #N`
- No YAML front matter (not supported for PR templates)
- Aligns with the project's existing `Closes #N` convention

## Test plan

- [ ] Opening a new PR against the repository pre-fills the body with the template
- [ ] Checkboxes render as interactive in GitHub UI
- [ ] `Closes #N` line is present

Closes #60