### PR TITLE
docs: add packages/core README and CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing to playwright-ppia
+
+Thank you for your interest in contributing! This guide covers everything you need to get up and running locally.
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Node.js | 18+ | Use the version in `.nvmrc` if present |
+| pnpm | 9+ | `npm install -g pnpm` |
+| Python | 3.11+ | Required for the AI Service |
+
+## Local Setup
+
+### 1. Clone and install TypeScript dependencies
+
+```bash
+git clone https://github.com/joseguillermomoreu-gif/playwright-ppia.git
+cd playwright-ppia
+pnpm install
+```
+
+### 2. Set up the Python AI Service
+
+```bash
+cd packages/core/python
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+```
+
+### 3. Configure environment variables
+
+Copy the example env file and fill in at least one API key:
+
+```bash
+cp packages/core/python/.env.example packages/core/python/.env
+# Edit .env and add OPENAI_API_KEY and/or ANTHROPIC_API_KEY
+```
+
+## Repository Layout
+
+```
+playwright-ppia/
+├── packages/core/
+│   ├── src/            # TypeScript CLI, agents, browser automation
+│   ├── python/         # Python AI Service (FastAPI + LLM integrations)
+│   └── package.json
+├── examples/           # Usage examples
+├── docs/               # Architecture and design documents
+└── pnpm-lock.yaml
+```
+
+## Quality Checks
+
+Run these before opening a pull request. The pre-push hook runs them automatically on `git push`.
+
+### TypeScript
+
+```bash
+cd packages/core
+pnpm lint        # ESLint
+pnpm typecheck   # tsc --noEmit
+pnpm test        # Vitest
+```
+
+### Python
+
+```bash
+cd packages/core/python
+ruff check .     # Linter
+mypy --strict src  # Type checker
+pytest           # Tests
+```
+
+## Branch and Commit Conventions
+
+- **Feature branches**: `feature/t{num}_{short_desc}` branched from `develop`
+- **Hotfix branches**: `hotfix/t{num}_{short_desc}` branched from `master`
+- **Commits**: follow [Conventional Commits](https://www.conventionalcommits.org/)
+  - `feat(scope): description` — new feature
+  - `fix(scope): description` — bug fix
+  - `chore(scope): description` — tooling, config, dependencies
+  - `docs(scope): description` — documentation only
+
+## PR Workflow
+
+1. Create a branch from `origin/develop` (never from the local branch directly):
+   ```bash
+   git fetch origin
+   git checkout -b feature/t{num}_{desc} origin/develop
+   ```
+2. Implement your changes
+3. Ensure all quality checks pass locally
+4. Push — the pre-push hook runs the full check suite automatically
+5. Open a PR against `develop`
+6. The PR body must include `Closes #N` to auto-close the related issue on merge
+
+## Release Process
+
+Releases are fully automated via `.github/workflows/release.yml`:
+
+1. Merging to `master` triggers the release workflow
+2. The workflow determines the version bump (patch / minor / major) from Conventional Commit prefixes
+3. It bumps `packages/core/package.json`, creates a git tag, and publishes to npm
+
+You do not need to manually bump versions or create tags.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ npx ppia generate "Validate user login with valid credentials"
 
 The Python service is bundled inside the npm package and managed transparently. You never need to install or configure Python manually.
 
+## Documentation
+
+Full CLI reference, configuration guide, and API details: [packages/core/README.md](packages/core/README.md)
+
+Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## License
 
 MIT

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,164 @@
+# playwright-ppia
+
+[![npm version](https://img.shields.io/npm/v/playwright-ppia.svg)](https://www.npmjs.com/package/playwright-ppia)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+AI-powered test generation framework for Playwright. Generate complete E2E tests from natural language descriptions — including Page Objects, selectors, and assertions — for your existing Playwright projects.
+
+## Prerequisites
+
+- **Node.js** 18+
+- **Python** 3.11+ (managed automatically by the CLI — no manual setup required)
+- **Playwright** installed in your project
+- At least one API key: `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`
+
+## Installation
+
+```bash
+npm install --save-dev playwright-ppia
+```
+
+## Quick Start
+
+### 1. Initialise your project
+
+```bash
+npx ppia setup add
+```
+
+This interactive command creates a `ppia.yaml` configuration file in your project root, guiding you through environment URLs, user credentials, and authentication flows.
+
+### 2. Generate a test
+
+```bash
+npx ppia generate "Validate user login with valid credentials"
+```
+
+`playwright-ppia` will:
+1. Start a browser and explore your application
+2. Analyse the page structure with AI
+3. Generate a complete `.spec.ts` file in `output/`
+4. Validate the test by running it with Playwright
+
+## CLI Reference
+
+### `ppia generate`
+
+Generate a new E2E test from a natural language description.
+
+```bash
+ppia generate "<description>" [--setup <env>] [--user <user>] [--model <model>]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--setup <env>` | Use a pre-configured environment and auth setup |
+| `--user <user>` | Specify a named user from `ppia.yaml` |
+| `--model <model>` | Override the generation model for this run |
+
+### `ppia run`
+
+Run one or more tests from your suite.
+
+```bash
+ppia run [--test <name>] [--suite <path>] [--user <user>] [--setup <env>]
+```
+
+### `ppia docs`
+
+Regenerate documentation artefacts (Page Object Model, Gherkin spec, Cucumber guide) from an existing test.
+
+```bash
+ppia docs --input output/<test_name>/test.spec.ts
+ppia docs --suite <path>
+```
+
+### `ppia compare`
+
+Compare two versions of a generated test side by side.
+
+```bash
+ppia compare --test <name> --before v1 --after v2
+```
+
+### `ppia suite`
+
+Manage your test suite history.
+
+```bash
+ppia suite list [--filter <keyword>]
+ppia suite show <test_name>
+ppia suite versions <test_name>
+ppia suite clean [--older-than 30d]
+```
+
+### `ppia setup`
+
+Create and manage authentication setups.
+
+```bash
+ppia setup add                          # interactive: create env + user + auth flow
+ppia setup list                         # list available setups in ppia.yaml
+ppia setup test <env> <user>            # verify a setup works correctly
+ppia setup remove <env>                 # remove a setup from ppia.yaml
+```
+
+## Configuration (`ppia.yaml`)
+
+`ppia.yaml` lives in your project root. All fields are optional except `project.name`.
+
+```yaml
+project:
+  name: my-project
+
+ai_service:
+  model_fast: gpt-4o-mini       # exploration model (default: gpt-4o-mini)
+  model_strong: gpt-4o          # generation model  (default: gpt-4o)
+  max_iterations: 25            # max exploration rounds (default: 25)
+  max_generation_attempts: 3    # generation retries   (default: 3)
+
+environments:
+  staging:
+    base_url: https://staging.example.com
+  production:
+    base_url: https://example.com
+
+users:
+  admin:
+    email: admin@example.com
+    password: ${ADMIN_PASSWORD}   # environment variable reference
+    role: administrator
+    auth_flow: login_form
+  guest:
+    role: anonymous
+
+output:
+  dir: ./output
+  artifacts: integrated           # integrated | docs
+```
+
+### API keys
+
+Set at least one of these environment variables before running `ppia`:
+
+```bash
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+## How It Works
+
+`playwright-ppia` uses a two-phase AI pipeline:
+
+1. **Exploration** — A browser session navigates your app while an AI model (`model_fast`) analyses each page state and decides the next action.
+2. **Generation** — A second AI model (`model_strong`) receives the full exploration report and generates a complete, validated `.spec.ts` file plus optional artefacts (Page Object Model, Gherkin spec, Cucumber guide).
+
+The Python AI service is bundled inside the npm package and launched automatically. You never need to install or configure Python manually.
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for local setup instructions, quality check commands, and the PR workflow.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- Add `packages/core/README.md`: public npm-oriented documentation with prerequisites, installation, quick start, full CLI reference, `ppia.yaml` configuration overview, and a link to `CONTRIBUTING.md`
- Add `CONTRIBUTING.md`: contributor onboarding guide covering local setup (TypeScript + Python), quality checks, branch/commit conventions, PR workflow, and release process
- Update root `README.md`: add links to `packages/core/README.md` and `CONTRIBUTING.md`

All files written in English (ADR-03: public package, international audience).
No content duplicated between root `README.md` and `packages/core/README.md`.

## Test plan

- [ ] `packages/core/README.md` exists and renders correctly on GitHub
- [ ] `CONTRIBUTING.md` exists at repo root
- [ ] Root `README.md` links to both new files
- [ ] No content duplication between root and package README

Closes #21