### PR TITLE
chore(release): enable real npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+          registry-url: https://registry.npmjs.org
 
       - name: Configure git
         run: |
@@ -61,7 +62,12 @@ jobs:
           git tag "${{ steps.version.outputs.new_version }}"
           git push origin master --follow-tags
 
-      - name: Publish npm (placeholder)
-        run: |
-          echo "npm publish will be enabled in T22"
-          echo "Version: ${{ steps.version.outputs.new_version }}"
+      - name: Build
+        working-directory: packages/core
+        run: pnpm build
+
+      - name: Publish to npm
+        working-directory: packages/core
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `registry-url: https://registry.npmjs.org` to `setup-node@v4` step
- Replace placeholder `echo` step with real `pnpm build` + `npm publish --access public`
- `NODE_AUTH_TOKEN` authenticated via `secrets.NPM_TOKEN` (set in repository secrets)

## Pre-merge checklist

- [x] `NPM_TOKEN` secret provisioned in GitHub Actions secrets
- [x] `packages/core/package.json` `files` field validated: `["dist/", "python/"]`
- [ ] Run `pnpm build` locally and confirm `dist/` is populated
- [ ] Run `npm pack --dry-run` from `packages/core/` and review the file list

## Test plan

- [ ] Merge to `master` triggers release workflow
- [ ] Build step completes successfully
- [ ] Publish step authenticates and publishes to npmjs.com
- [ ] `NODE_AUTH_TOKEN` does not appear in any log line

Closes #22