### PR TITLE
fix(github): make security warnings visible in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,17 +32,18 @@ labels: ["bug"]
 - Python version:
 - Operating system:
 - Playwright version:
+-->
 
 > Do not include API keys, passwords, or any credentials.
 > Redact any sensitive values before pasting.
--->
 
 ## Error Output / Logs
 
 <!--
 Paste the full stack trace or terminal output here.
-Redact any sensitive values before pasting.
 -->
+
+> Redact any sensitive values before pasting.
 
 ## Additional Context
 


### PR DESCRIPTION
## Summary

- Move security blockquotes out of HTML comments in `bug_report.md`
- Environment section: `> Do not include API keys, passwords, or any credentials.` now renders visibly
- Error Output section: `> Redact any sensitive values before pasting.` now renders visibly
- Placeholder instructions for form fields remain as `<!-- -->` (correct behavior)

Detected by **github-community-team** post-merge review against SDD security requirements.

## Test plan

- [ ] Open a new bug report issue on GitHub
- [ ] Security warnings are visible in the rendered template (not hidden in comment mode)
- [ ] Placeholder instructions for fields are still hidden until editing