### PR TITLE
[T24] Startup check: health poll, price fetch, cost estimate, display

### DIFF
--- a/packages/core/python/src/application/dto/prepare_input.py
+++ b/packages/core/python/src/application/dto/prepare_input.py
@@ -14,3 +14,4 @@ class PrepareInputResponse(BaseModel):
     test_name: str
     parameters: dict[str, str]
     tokens_used: int
+    estimated_cost: float = 0.0

--- a/packages/core/python/src/application/dto/startup.py
+++ b/packages/core/python/src/application/dto/startup.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class StartupInfoResponse(BaseModel):
+    version: str
+    model_fast: str
+    model_strong: str

--- a/packages/core/python/src/application/use_cases/prepare_input/prepare_input_use_case.py
+++ b/packages/core/python/src/application/use_cases/prepare_input/prepare_input_use_case.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from src.application.dto.prepare_input import PrepareInputRequest, PrepareInputResponse
 from src.application.shared.llm_response_parser import parse_llm_json
+from src.application.use_cases.startup.cost_estimator import estimate_cost
 from src.domain.repository.llm_service import LlmService
+from src.infrastructure.pricing.pricing_store import PricingStore
 from src.infrastructure.prompts.prepare_input_prompt import (
     PREPARE_INPUT_SYSTEM_PROMPT,
     build_prepare_input_prompt,
@@ -10,8 +12,17 @@ from src.infrastructure.prompts.prepare_input_prompt import (
 
 
 class PrepareInputUseCase:
-    def __init__(self, llm_service: LlmService) -> None:
+    def __init__(
+        self,
+        llm_service: LlmService,
+        pricing_store: PricingStore | None = None,
+        model_fast_id: str = "",
+        model_strong_id: str = "",
+    ) -> None:
         self._llm_service = llm_service
+        self._pricing_store = pricing_store
+        self._model_fast_id = model_fast_id
+        self._model_strong_id = model_strong_id
 
     async def execute(self, request: PrepareInputRequest) -> PrepareInputResponse:
         prompt = build_prepare_input_prompt(request.raw_input)
@@ -23,13 +34,39 @@ class PrepareInputUseCase:
         tokens_used = await self._llm_service.count_tokens(request.raw_input)
         parsed = parse_llm_json(raw_response, context="prepare-input")
 
+        estimated_cost = self._compute_estimated_cost(request)
+
         return PrepareInputResponse(
             url=str(parsed.get("url", "")),
             objective=str(parsed.get("objective", "")),
             test_name=str(parsed.get("test_name", "")),
             parameters=self._extract_parameters(parsed.get("parameters", {})),
             tokens_used=tokens_used,
+            estimated_cost=estimated_cost,
         )
+
+    def _compute_estimated_cost(self, request: PrepareInputRequest) -> float:
+        if self._pricing_store is None:
+            return 0.0
+
+        prices = self._pricing_store.read()
+        if not prices:
+            return 0.0
+
+        # Use request.model override when provided, fall back to configured IDs
+        fast_key = request.model if request.model else self._model_fast_id
+        strong_key = self._model_strong_id
+
+        model_fast_price = prices.get(fast_key) if fast_key else None
+        model_strong_price = prices.get(strong_key) if strong_key else None
+
+        # Default estimated_actions to 1 for the prepare_input phase
+        estimate = estimate_cost(
+            estimated_actions=1,
+            model_fast_price=model_fast_price,
+            model_strong_price=model_strong_price,
+        )
+        return estimate.total
 
     @staticmethod
     def _extract_parameters(raw: object) -> dict[str, str]:

--- a/packages/core/python/src/application/use_cases/startup/cost_estimator.py
+++ b/packages/core/python/src/application/use_cases/startup/cost_estimator.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.application.use_cases.startup.token_budgets import (
+    AVG_TOKENS_GENERATION,
+    AVG_TOKENS_PER_ACTION,
+)
+from src.domain.model.model_price import ModelPrice
+
+
+@dataclass
+class CostEstimate:
+    exploration: float
+    generation: float
+    total: float
+
+
+def estimate_cost(
+    estimated_actions: int,
+    model_fast_price: ModelPrice | None,
+    model_strong_price: ModelPrice | None,
+) -> CostEstimate:
+    """Estimate cost in USD for an exploration + generation session.
+
+    Args:
+        estimated_actions: Number of exploration rounds expected.
+        model_fast_price: Pricing for the fast model (exploration phase).
+            If None, exploration cost is 0.0.
+        model_strong_price: Pricing for the strong model (generation phase).
+            If None, generation cost is 0.0.
+
+    Returns:
+        CostEstimate with exploration, generation and total costs in USD.
+    """
+    if model_fast_price is not None:
+        exploration = (
+            estimated_actions
+            * AVG_TOKENS_PER_ACTION
+            * model_fast_price.input_usd_per_token
+        )
+    else:
+        exploration = 0.0
+
+    if model_strong_price is not None:
+        generation = AVG_TOKENS_GENERATION * model_strong_price.input_usd_per_token
+    else:
+        generation = 0.0
+
+    total = exploration + generation
+
+    return CostEstimate(exploration=exploration, generation=generation, total=total)

--- a/packages/core/python/src/application/use_cases/startup/token_budgets.py
+++ b/packages/core/python/src/application/use_cases/startup/token_budgets.py
@@ -1,0 +1,4 @@
+from __future__ import annotations
+
+AVG_TOKENS_PER_ACTION: int = 2_500
+AVG_TOKENS_GENERATION: int = 8_000

--- a/packages/core/python/src/domain/model/model_price.py
+++ b/packages/core/python/src/domain/model/model_price.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ModelPrice(BaseModel):
+    model_id: str
+    input_usd_per_token: float
+    output_usd_per_token: float
+    context_length: int
+    fetched_at: str  # ISO date UTC

--- a/packages/core/python/src/domain/repository/pricing_port.py
+++ b/packages/core/python/src/domain/repository/pricing_port.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from src.domain.model.model_price import ModelPrice
+
+
+class PricingPort(ABC):
+    @abstractmethod
+    async def fetch_prices(self, model_ids: list[str]) -> list[ModelPrice]:
+        """Fetch pricing data for the given model IDs."""

--- a/packages/core/python/src/infrastructure/config/dependency_injection.py
+++ b/packages/core/python/src/infrastructure/config/dependency_injection.py
@@ -2,6 +2,7 @@ from src.domain.repository.llm_service import LlmService
 from src.infrastructure.ai.anthropic.claude_llm_service import ClaudeLlmService
 from src.infrastructure.ai.openai.openai_llm_service import OpenAiLlmService
 from src.infrastructure.config.settings import Settings, get_settings
+from src.infrastructure.pricing.pricing_store import PricingStore
 from src.infrastructure.session.session_store import SessionStore
 
 
@@ -10,6 +11,7 @@ class Container:
         self.settings = settings or get_settings()
         self._llm_service: LlmService | None = None
         self._session_store: SessionStore | None = None
+        self._pricing_stores: dict[str, PricingStore] = {}
 
     def get_session_store(self) -> SessionStore:
         if self._session_store is None:
@@ -23,6 +25,11 @@ class Container:
             return self._llm_service
         override_settings = self.settings.model_copy(update={"default_model": model_override})
         return _create_llm_service(override_settings)
+
+    def get_pricing_store(self, project_root: str) -> PricingStore:
+        if project_root not in self._pricing_stores:
+            self._pricing_stores[project_root] = PricingStore(project_root)
+        return self._pricing_stores[project_root]
 
 
 def _create_llm_service(settings: Settings) -> LlmService:

--- a/packages/core/python/src/infrastructure/config/settings.py
+++ b/packages/core/python/src/infrastructure/config/settings.py
@@ -5,6 +5,8 @@ class Settings(BaseSettings):
     openai_api_key: str = ""
     anthropic_api_key: str = ""
     default_model: str = "gpt-4o"
+    model_fast: str = "gpt-4o-mini"
+    model_strong: str = "gpt-4o"
     port: int = 8765
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}

--- a/packages/core/python/src/infrastructure/pricing/openrouter_pricing_adapter.py
+++ b/packages/core/python/src/infrastructure/pricing/openrouter_pricing_adapter.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+
+from src.domain.model.model_price import ModelPrice
+from src.domain.repository.pricing_port import PricingPort
+
+_OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+_TIMEOUT_SECONDS = 2.0
+
+
+def _normalize_model_id(openrouter_id: str) -> str:
+    """Strip provider prefix from OpenRouter model ID.
+
+    e.g. 'openai/gpt-4o-mini' -> 'gpt-4o-mini'
+    """
+    if "/" in openrouter_id:
+        return openrouter_id.split("/", 1)[1]
+    return openrouter_id
+
+
+class OpenRouterPricingAdapter(PricingPort):
+    async def fetch_prices(self, model_ids: list[str]) -> list[ModelPrice]:
+        """Fetch prices from OpenRouter for the requested model IDs.
+
+        Returns an empty list on any network or parsing error (silent fallback).
+        """
+        try:
+            async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+                response = await client.get(_OPENROUTER_MODELS_URL)
+                response.raise_for_status()
+                payload: dict[str, object] = response.json()
+
+            raw_models: list[dict[str, object]] = payload.get("data", [])  # type: ignore[assignment]
+            fetched_at = datetime.now(timezone.utc).date().isoformat()
+
+            result: list[ModelPrice] = []
+            requested = set(model_ids)
+
+            for entry in raw_models:
+                openrouter_id = str(entry.get("id", ""))
+                normalized = _normalize_model_id(openrouter_id)
+
+                if normalized not in requested:
+                    continue
+
+                pricing: dict[str, object] = entry.get("pricing", {})  # type: ignore[assignment]
+
+                input_usd = float(str(pricing.get("prompt") or "0"))
+                output_usd = float(str(pricing.get("completion") or "0"))
+                context_length = int(str(entry.get("context_length") or "0"))
+
+                result.append(
+                    ModelPrice(
+                        model_id=normalized,
+                        input_usd_per_token=input_usd,
+                        output_usd_per_token=output_usd,
+                        context_length=context_length,
+                        fetched_at=fetched_at,
+                    )
+                )
+
+            return result
+
+        except Exception:  # noqa: BLE001
+            return []

--- a/packages/core/python/src/infrastructure/pricing/pricing_store.py
+++ b/packages/core/python/src/infrastructure/pricing/pricing_store.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from src.domain.model.model_price import ModelPrice
+
+_SCHEMA_VERSION = 1
+_CACHE_FILE = ".ppia/llm-pricing.json"
+
+
+class PricingStore:
+    def __init__(self, project_root: str) -> None:
+        self._cache_path = Path(project_root) / _CACHE_FILE
+
+    def read(self) -> dict[str, ModelPrice]:
+        """Read cached prices. Returns empty dict if file is missing or corrupted."""
+        try:
+            raw = self._cache_path.read_text(encoding="utf-8")
+            data: dict[str, object] = json.loads(raw)
+            models_raw: dict[str, object] = data.get("models", {})  # type: ignore[assignment]
+            result: dict[str, ModelPrice] = {}
+            for model_id, fields in models_raw.items():
+                result[model_id] = ModelPrice.model_validate(fields)
+            return result
+        except Exception:  # noqa: BLE001
+            return {}
+
+    def write(self, prices: list[ModelPrice]) -> None:
+        """Atomically write prices to cache file."""
+        fetched_at = datetime.now(timezone.utc).date().isoformat()
+        models: dict[str, object] = {
+            price.model_id: price.model_dump() for price in prices
+        }
+        payload: dict[str, object] = {
+            "schema_version": _SCHEMA_VERSION,
+            "fetched_at": fetched_at,
+            "models": models,
+        }
+
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+        tmp_path = self._cache_path.with_suffix(".tmp")
+        try:
+            tmp_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            os.replace(tmp_path, self._cache_path)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
+
+    def is_fresh(self) -> bool:
+        """Return True if the cache was fetched today (UTC)."""
+        try:
+            raw = self._cache_path.read_text(encoding="utf-8")
+            data: dict[str, object] = json.loads(raw)
+            fetched_at = str(data.get("fetched_at", ""))
+            today = datetime.now(timezone.utc).date().isoformat()
+            return fetched_at == today
+        except Exception:  # noqa: BLE001
+            return False

--- a/packages/core/python/src/server.py
+++ b/packages/core/python/src/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from fastapi import FastAPI, HTTPException
 
 from src.application.dto.explore import (
@@ -13,18 +15,30 @@ from src.application.dto.generate import (
     GenerateTestResponse,
 )
 from src.application.dto.prepare_input import PrepareInputRequest, PrepareInputResponse
+from src.application.dto.startup import StartupInfoResponse
 from src.application.use_cases.explore.explore_use_case import ExploreUseCase
 from src.application.use_cases.generate.generate_artifacts_use_case import GenerateArtifactsUseCase
 from src.application.use_cases.generate.generate_test_use_case import GenerateTestUseCase
 from src.application.use_cases.prepare_input.prepare_input_use_case import PrepareInputUseCase
 from src.infrastructure.config.dependency_injection import get_container
+from src.infrastructure.config.settings import get_settings
 
 app = FastAPI(title="PPIA AI Service", version="0.1.0")
 
 
 @app.get("/ping")
 async def ping() -> dict[str, str]:
-    return {"status": "ok", "version": "0.1.0"}
+    return {"status": "ok", "version": app.version}
+
+
+@app.get("/startup-info")
+async def startup_info() -> StartupInfoResponse:
+    settings = get_settings()
+    return StartupInfoResponse(
+        version=app.version,
+        model_fast=settings.model_fast,
+        model_strong=settings.model_strong,
+    )
 
 
 @app.post("/prepare-input")

--- a/packages/core/python/tests/application/startup/test_cost_estimator.py
+++ b/packages/core/python/tests/application/startup/test_cost_estimator.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from src.application.use_cases.startup.cost_estimator import CostEstimate, estimate_cost
+from src.application.use_cases.startup.token_budgets import (
+    AVG_TOKENS_GENERATION,
+    AVG_TOKENS_PER_ACTION,
+)
+from src.domain.model.model_price import ModelPrice
+
+
+def _make_price(model_id: str, input_usd_per_token: float) -> ModelPrice:
+    return ModelPrice(
+        model_id=model_id,
+        input_usd_per_token=input_usd_per_token,
+        output_usd_per_token=input_usd_per_token * 3,
+        context_length=128_000,
+        fetched_at="2026-03-18",
+    )
+
+
+class TestEstimateCost:
+    def test_estimate_cost_with_both_prices(self) -> None:
+        fast = _make_price("gpt-4o-mini", 0.00000015)
+        strong = _make_price("gpt-4o", 0.0000025)
+        actions = 10
+
+        result = estimate_cost(
+            estimated_actions=actions,
+            model_fast_price=fast,
+            model_strong_price=strong,
+        )
+
+        expected_exploration = actions * AVG_TOKENS_PER_ACTION * fast.input_usd_per_token
+        expected_generation = AVG_TOKENS_GENERATION * strong.input_usd_per_token
+
+        assert isinstance(result, CostEstimate)
+        assert abs(result.exploration - expected_exploration) < 1e-8
+        assert abs(result.generation - expected_generation) < 1e-8
+        assert abs(result.total - (result.exploration + result.generation)) < 1e-8
+
+    def test_estimate_cost_no_fast_price(self) -> None:
+        strong = _make_price("gpt-4o", 0.0000025)
+
+        result = estimate_cost(
+            estimated_actions=5,
+            model_fast_price=None,
+            model_strong_price=strong,
+        )
+
+        assert result.exploration == 0.0
+        assert result.generation > 0.0
+        assert abs(result.total - result.generation) < 1e-8
+
+    def test_estimate_cost_no_strong_price(self) -> None:
+        fast = _make_price("gpt-4o-mini", 0.00000015)
+
+        result = estimate_cost(
+            estimated_actions=5,
+            model_fast_price=fast,
+            model_strong_price=None,
+        )
+
+        assert result.generation == 0.0
+        assert result.exploration > 0.0
+        assert abs(result.total - result.exploration) < 1e-8
+
+    def test_estimate_cost_zero_actions(self) -> None:
+        fast = _make_price("gpt-4o-mini", 0.00000015)
+        strong = _make_price("gpt-4o", 0.0000025)
+
+        result = estimate_cost(
+            estimated_actions=0,
+            model_fast_price=fast,
+            model_strong_price=strong,
+        )
+
+        assert result.exploration == 0.0
+        assert result.generation > 0.0
+        assert abs(result.total - result.generation) < 1e-8
+
+    @pytest.mark.parametrize(
+        ("actions", "fast_input", "strong_input"),
+        [
+            (1, 0.000001, 0.000005),
+            (20, 0.0000002, 0.000003),
+            (100, 0.00000015, 0.0000025),
+            (0, 0.000001, 0.000005),
+        ],
+    )
+    def test_total_equals_sum(
+        self, actions: int, fast_input: float, strong_input: float
+    ) -> None:
+        fast = _make_price("fast-model", fast_input)
+        strong = _make_price("strong-model", strong_input)
+
+        result = estimate_cost(
+            estimated_actions=actions,
+            model_fast_price=fast,
+            model_strong_price=strong,
+        )
+
+        assert abs(result.total - (result.exploration + result.generation)) < 1e-8

--- a/packages/core/python/tests/infrastructure/test_openrouter_adapter.py
+++ b/packages/core/python/tests/infrastructure/test_openrouter_adapter.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from src.infrastructure.pricing.openrouter_pricing_adapter import OpenRouterPricingAdapter
+
+
+def _make_openrouter_response(entries: list[dict[str, object]]) -> MagicMock:
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.json.return_value = {"data": entries}
+    mock_response.raise_for_status = MagicMock()
+    return mock_response
+
+
+_SAMPLE_ENTRIES: list[dict[str, object]] = [
+    {
+        "id": "openai/gpt-4o-mini",
+        "context_length": 128000,
+        "pricing": {"prompt": "0.00000015", "completion": "0.0000006"},
+    },
+    {
+        "id": "anthropic/claude-3-haiku",
+        "context_length": 200000,
+        "pricing": {"prompt": "0.00000025", "completion": "0.00000125"},
+    },
+    {
+        "id": "google/gemini-flash-1.5",
+        "context_length": 1000000,
+        "pricing": {"prompt": "0.000000075", "completion": "0.0000003"},
+    },
+]
+
+
+class TestOpenRouterPricingAdapter:
+    @pytest.mark.asyncio
+    async def test_fetch_prices_returns_empty_on_network_error(self) -> None:
+        adapter = OpenRouterPricingAdapter()
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+            mock_client_cls.return_value = mock_client
+
+            result = await adapter.fetch_prices(["gpt-4o-mini"])
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_prices_filters_by_model_id(self) -> None:
+        adapter = OpenRouterPricingAdapter()
+        mock_response = _make_openrouter_response(_SAMPLE_ENTRIES)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await adapter.fetch_prices(["gpt-4o-mini"])
+
+        assert len(result) == 1
+        assert result[0].model_id == "gpt-4o-mini"
+
+    @pytest.mark.asyncio
+    async def test_fetch_prices_normalizes_model_id(self) -> None:
+        adapter = OpenRouterPricingAdapter()
+        mock_response = _make_openrouter_response(_SAMPLE_ENTRIES)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await adapter.fetch_prices(["gpt-4o-mini", "claude-3-haiku"])
+
+        model_ids = {p.model_id for p in result}
+        assert "gpt-4o-mini" in model_ids
+        assert "claude-3-haiku" in model_ids
+        # Original prefixed IDs must NOT appear
+        assert "openai/gpt-4o-mini" not in model_ids
+        assert "anthropic/claude-3-haiku" not in model_ids
+
+    @pytest.mark.asyncio
+    async def test_fetch_prices_maps_pricing_fields(self) -> None:
+        adapter = OpenRouterPricingAdapter()
+        mock_response = _make_openrouter_response(_SAMPLE_ENTRIES)
+
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client_cls.return_value = mock_client
+
+            result = await adapter.fetch_prices(["gpt-4o-mini"])
+
+        price = result[0]
+        assert price.input_usd_per_token == pytest.approx(0.00000015)
+        assert price.output_usd_per_token == pytest.approx(0.0000006)
+        assert price.context_length == 128000
+        assert price.fetched_at != ""

--- a/packages/core/python/tests/infrastructure/test_pricing_store.py
+++ b/packages/core/python/tests/infrastructure/test_pricing_store.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from src.domain.model.model_price import ModelPrice
+from src.infrastructure.pricing.pricing_store import PricingStore
+
+
+def _make_prices() -> list[ModelPrice]:
+    today = datetime.now(timezone.utc).date().isoformat()
+    return [
+        ModelPrice(
+            model_id="gpt-4o-mini",
+            input_usd_per_token=0.00000015,
+            output_usd_per_token=0.0000006,
+            context_length=128000,
+            fetched_at=today,
+        ),
+        ModelPrice(
+            model_id="claude-3-haiku",
+            input_usd_per_token=0.00000025,
+            output_usd_per_token=0.00000125,
+            context_length=200000,
+            fetched_at=today,
+        ),
+    ]
+
+
+class TestPricingStore:
+    def test_write_and_read_roundtrip(self, tmp_path: Path) -> None:
+        store = PricingStore(str(tmp_path))
+        prices = _make_prices()
+
+        store.write(prices)
+        result = store.read()
+
+        assert len(result) == 2
+        gpt = result["gpt-4o-mini"]
+        assert gpt.model_id == "gpt-4o-mini"
+        assert gpt.input_usd_per_token == pytest.approx(0.00000015)
+        assert gpt.output_usd_per_token == pytest.approx(0.0000006)
+        assert gpt.context_length == 128000
+
+        claude = result["claude-3-haiku"]
+        assert claude.model_id == "claude-3-haiku"
+
+    def test_atomic_write_does_not_corrupt_on_partial(self, tmp_path: Path) -> None:
+        """After a successful write the .tmp file must not exist."""
+        store = PricingStore(str(tmp_path))
+        prices = _make_prices()
+
+        store.write(prices)
+
+        tmp_file = tmp_path / ".ppia" / "llm-pricing.tmp"
+        assert not tmp_file.exists()
+
+    def test_is_fresh_returns_true_for_today(self, tmp_path: Path) -> None:
+        store = PricingStore(str(tmp_path))
+        prices = _make_prices()
+
+        store.write(prices)
+
+        assert store.is_fresh() is True
+
+    def test_is_fresh_returns_false_for_yesterday(self, tmp_path: Path) -> None:
+        store = PricingStore(str(tmp_path))
+        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
+
+        cache_dir = tmp_path / ".ppia"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = cache_dir / "llm-pricing.json"
+        cache_file.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "fetched_at": yesterday,
+                    "models": {},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        assert store.is_fresh() is False
+
+    def test_read_returns_empty_if_file_missing(self, tmp_path: Path) -> None:
+        store = PricingStore(str(tmp_path))
+
+        result = store.read()
+
+        assert result == {}
+
+    def test_read_returns_empty_if_file_corrupted(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / ".ppia"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "llm-pricing.json").write_text("not valid json", encoding="utf-8")
+
+        store = PricingStore(str(tmp_path))
+        result = store.read()
+
+        assert result == {}

--- a/packages/core/python/tests/test_startup_endpoints.py
+++ b/packages/core/python/tests/test_startup_endpoints.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from src.server import app
+
+client = TestClient(app)
+
+
+def test_ping_returns_200() -> None:
+    response = client.get("/ping")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": "0.1.0"}
+
+
+def test_ping_is_fast() -> None:
+    with patch("src.server.get_container") as mock_get_container:
+        response = client.get("/ping")
+    assert response.status_code == 200
+    mock_get_container.assert_not_called()
+
+
+def test_startup_info_returns_version_and_models() -> None:
+    response = client.get("/startup-info")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["version"] != ""
+    assert data["model_fast"] != ""
+    assert data["model_strong"] != ""

--- a/packages/core/src/ai/AiServiceClient.ts
+++ b/packages/core/src/ai/AiServiceClient.ts
@@ -11,6 +11,7 @@ import type {
   PingResponse,
   PrepareInputRequest,
   PrepareInputResponse,
+  StartupInfoResponse,
 } from './AiServiceTypes.js';
 
 /**
@@ -84,6 +85,37 @@ export class AiServiceClient {
     return this.post<GenerateArtifactsResponse>(
       `/session/${sessionId}/generate-artifacts`,
       request,
+    );
+  }
+
+  async getStartupInfo(): Promise<StartupInfoResponse> {
+    return this.get<StartupInfoResponse>('/startup-info');
+  }
+
+  async waitForReady(timeoutMs: number): Promise<void> {
+    const maxAttempts = 10;
+    const interval = 300;
+    const deadline = Date.now() + timeoutMs;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (Date.now() > deadline) {
+        break;
+      }
+      try {
+        await this.ping();
+        return;
+      } catch {
+        // Not ready yet
+      }
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, interval);
+      });
+    }
+
+    throw new AiServiceError(
+      `AI Service did not become ready within ${String(timeoutMs)}ms`,
+      undefined,
+      '/ping',
     );
   }
 

--- a/packages/core/src/ai/AiServiceTypes.ts
+++ b/packages/core/src/ai/AiServiceTypes.ts
@@ -71,3 +71,11 @@ export interface GenerateArtifactsResponse {
   cucumberMd: string;
   tokensUsed: number;
 }
+
+// --- Startup Info ---
+
+export interface StartupInfoResponse {
+  version: string;
+  modelFast: string;
+  modelStrong: string;
+}

--- a/packages/core/src/ai/PricingFetcher.test.ts
+++ b/packages/core/src/ai/PricingFetcher.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PricingFetcher } from './PricingFetcher.js';
+
+// Mock node:fs/promises
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Get mocked references
+const fsMock = await import('node:fs/promises');
+const readFileMock = vi.mocked(fsMock.readFile);
+
+// Store original fetch
+const originalFetch = globalThis.fetch;
+
+describe('PricingFetcher', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns cached prices when cache is fresh today', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    const cacheData = {
+      fetched_at: today,
+      models: {
+        'gpt-4o-mini': {
+          modelId: 'gpt-4o-mini',
+          inputUsdPerToken: 0.00000015,
+          outputUsdPerToken: 0.0000006,
+        },
+        'gpt-4o': {
+          modelId: 'gpt-4o',
+          inputUsdPerToken: 0.000005,
+          outputUsdPerToken: 0.000015,
+        },
+      },
+    };
+
+    readFileMock.mockResolvedValueOnce(JSON.stringify(cacheData));
+
+    const fetcher = new PricingFetcher('/fake/project');
+    const result = await fetcher.fetchPrices(['gpt-4o-mini', 'gpt-4o']);
+
+    expect(result.cached).toBe(true);
+    expect(result.prices).toHaveLength(2);
+    expect(result.prices[0]?.modelId).toBe('gpt-4o-mini');
+    expect(result.prices[1]?.modelId).toBe('gpt-4o');
+  });
+
+  it('fetches from network when cache is missing', async () => {
+    // Cache miss
+    readFileMock.mockRejectedValueOnce(new Error('ENOENT'));
+
+    const openRouterResponse = {
+      data: [
+        {
+          id: 'openai/gpt-4o-mini',
+          pricing: { prompt: '0.00000015', completion: '0.0000006' },
+          context_length: 128000,
+        },
+        {
+          id: 'openai/gpt-4o',
+          pricing: { prompt: '0.000005', completion: '0.000015' },
+          context_length: 128000,
+        },
+      ],
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValueOnce({
+      json: () => Promise.resolve(openRouterResponse),
+    } as unknown as Response);
+
+    const fetcher = new PricingFetcher('/fake/project');
+    const result = await fetcher.fetchPrices(['gpt-4o-mini', 'gpt-4o']);
+
+    expect(result.cached).toBe(false);
+    expect(result.prices).toHaveLength(2);
+    expect(result.prices[0]?.modelId).toBe('gpt-4o-mini');
+    expect(result.prices[0]?.inputUsdPerToken).toBe(0.00000015);
+    expect(result.prices[1]?.modelId).toBe('gpt-4o');
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://openrouter.ai/api/v1/models',
+      expect.objectContaining({ signal: expect.anything() as AbortSignal }),
+    );
+  });
+
+  it('returns empty prices on network error', async () => {
+    // Cache miss
+    readFileMock.mockRejectedValueOnce(new Error('ENOENT'));
+
+    // Network error
+    globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error('Network failure'));
+
+    const fetcher = new PricingFetcher('/fake/project');
+    const result = await fetcher.fetchPrices(['gpt-4o-mini']);
+
+    expect(result.cached).toBe(false);
+    expect(result.prices).toHaveLength(0);
+  });
+});

--- a/packages/core/src/ai/PricingFetcher.ts
+++ b/packages/core/src/ai/PricingFetcher.ts
@@ -1,0 +1,112 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+export interface ModelPricing {
+  modelId: string;
+  inputUsdPerToken: number;
+  outputUsdPerToken: number;
+}
+
+export interface PricingResult {
+  prices: ModelPricing[];
+  cached: boolean;
+}
+
+interface CacheSchema {
+  fetched_at: string;
+  models: Record<string, ModelPricing>;
+}
+
+interface OpenRouterModel {
+  id: string;
+  pricing: { prompt: string; completion: string };
+  context_length: number;
+}
+
+interface OpenRouterResponse {
+  data: OpenRouterModel[];
+}
+
+function todayUTC(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function normalizeId(openRouterId: string): string {
+  const slashIndex = openRouterId.indexOf('/');
+  return slashIndex >= 0 ? openRouterId.slice(slashIndex + 1) : openRouterId;
+}
+
+export class PricingFetcher {
+  private readonly cachePath: string;
+
+  constructor(private readonly projectRoot: string) {
+    this.cachePath = join(projectRoot, '.ppia', 'llm-pricing.json');
+  }
+
+  async fetchPrices(modelIds: string[]): Promise<PricingResult> {
+    try {
+      return await this.doFetch(modelIds);
+    } catch {
+      return { prices: [], cached: false };
+    }
+  }
+
+  private async doFetch(modelIds: string[]): Promise<PricingResult> {
+    // Try cache first
+    const cache = await this.readCache();
+    if (cache !== null && cache.fetched_at === todayUTC()) {
+      const prices = modelIds
+        .map((id) => cache.models[id])
+        .filter((p): p is ModelPricing => p !== undefined);
+      return { prices, cached: true };
+    }
+
+    // Fetch from network
+    const controller = new AbortController();
+    const timeout = setTimeout(() => { controller.abort(); }, 2000);
+
+    let response: Response;
+    try {
+      response = await fetch('https://openrouter.ai/api/v1/models', {
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const body = (await response.json()) as OpenRouterResponse;
+
+    // Build models map
+    const models: Record<string, ModelPricing> = {};
+    for (const model of body.data) {
+      const normalId = normalizeId(model.id);
+      models[normalId] = {
+        modelId: normalId,
+        inputUsdPerToken: Number(model.pricing.prompt),
+        outputUsdPerToken: Number(model.pricing.completion),
+      };
+    }
+
+    // Atomic write
+    const newCache: CacheSchema = { fetched_at: todayUTC(), models };
+    const dir = dirname(this.cachePath);
+    await mkdir(dir, { recursive: true });
+    const tmpPath = `${this.cachePath}.tmp`;
+    await writeFile(tmpPath, JSON.stringify(newCache), 'utf-8');
+    await rename(tmpPath, this.cachePath);
+
+    const prices = modelIds
+      .map((id) => models[id])
+      .filter((p): p is ModelPricing => p !== undefined);
+    return { prices, cached: false };
+  }
+
+  private async readCache(): Promise<CacheSchema | null> {
+    try {
+      const raw = await readFile(this.cachePath, 'utf-8');
+      return JSON.parse(raw) as CacheSchema;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/core/src/cli/LastStartupStore.test.ts
+++ b/packages/core/src/cli/LastStartupStore.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LastStartupStore } from './LastStartupStore.js';
+
+describe('LastStartupStore (mocked fs)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('hasRanToday returns false when file missing', async () => {
+    const store = new LastStartupStore('/nonexistent/project');
+    const result = await store.hasRanToday();
+    expect(result).toBe(false);
+  });
+
+  it('hasRanToday returns false for yesterday', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'ppia-test-'));
+    try {
+      const store = new LastStartupStore(tmp);
+      // Write a date that is yesterday
+      const yesterday = new Date();
+      yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+      const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+      const { mkdir, writeFile } = await import('node:fs/promises');
+      await mkdir(join(tmp, '.ppia'), { recursive: true });
+      await writeFile(
+        join(tmp, '.ppia', 'last-startup.json'),
+        JSON.stringify({ ran_at: yesterdayStr }),
+        'utf-8',
+      );
+
+      const result = await store.hasRanToday();
+      expect(result).toBe(false);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('LastStartupStore (real tmpdir)', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'ppia-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('markRan writes today date', async () => {
+    const store = new LastStartupStore(tmp);
+    await store.markRan();
+
+    const raw = await readFile(join(tmp, '.ppia', 'last-startup.json'), 'utf-8');
+    const data = JSON.parse(raw) as { ran_at: string };
+    const today = new Date().toISOString().slice(0, 10);
+    expect(data.ran_at).toBe(today);
+  });
+
+  it('hasRanToday returns true after markRan', async () => {
+    const store = new LastStartupStore(tmp);
+    await store.markRan();
+    const result = await store.hasRanToday();
+    expect(result).toBe(true);
+  });
+});

--- a/packages/core/src/cli/LastStartupStore.ts
+++ b/packages/core/src/cli/LastStartupStore.ts
@@ -1,0 +1,35 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+interface LastStartupData {
+  ran_at: string;
+}
+
+function todayUTC(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export class LastStartupStore {
+  private readonly filePath: string;
+
+  constructor(projectRoot: string) {
+    this.filePath = join(projectRoot, '.ppia', 'last-startup.json');
+  }
+
+  async hasRanToday(): Promise<boolean> {
+    try {
+      const raw = await readFile(this.filePath, 'utf-8');
+      const data = JSON.parse(raw) as LastStartupData;
+      return data.ran_at === todayUTC();
+    } catch {
+      return false;
+    }
+  }
+
+  async markRan(): Promise<void> {
+    const dir = dirname(this.filePath);
+    await mkdir(dir, { recursive: true });
+    const payload: LastStartupData = { ran_at: todayUTC() };
+    await writeFile(this.filePath, JSON.stringify(payload), 'utf-8');
+  }
+}

--- a/packages/core/src/cli/StartupChecker.test.ts
+++ b/packages/core/src/cli/StartupChecker.test.ts
@@ -49,13 +49,14 @@ describe('StartupChecker', () => {
 
   it('skips startup when hasRanToday returns true', async () => {
     mockHasRanToday.mockResolvedValueOnce(true);
-    const mockClient = buildMockClient();
+    const waitForReady = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const mockClient = buildMockClient({ waitForReady });
 
     const checker = new StartupChecker('/fake', mockClient);
     const result = await checker.run(10);
 
     expect(result.skipped).toBe(true);
-    expect(mockClient.waitForReady).not.toHaveBeenCalled();
+    expect(waitForReady).not.toHaveBeenCalled();
   });
 
   it('does not call fetchPrices when skipped', async () => {

--- a/packages/core/src/cli/StartupChecker.test.ts
+++ b/packages/core/src/cli/StartupChecker.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AiServiceClient } from '../ai/AiServiceClient.js';
+import type { PricingResult } from '../ai/PricingFetcher.js';
+import { StartupChecker } from './StartupChecker.js';
+
+// Mock LastStartupStore
+const mockHasRanToday = vi.fn<() => Promise<boolean>>().mockResolvedValue(false);
+const mockMarkRan = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+vi.mock('./LastStartupStore.js', () => ({
+  LastStartupStore: vi.fn().mockImplementation(() => ({
+    hasRanToday: mockHasRanToday,
+    markRan: mockMarkRan,
+  })),
+}));
+
+// Mock PricingFetcher
+const mockFetchPrices = vi.fn<(ids: string[]) => Promise<PricingResult>>();
+vi.mock('../ai/PricingFetcher.js', () => ({
+  PricingFetcher: vi.fn().mockImplementation(() => ({
+    fetchPrices: mockFetchPrices,
+  })),
+}));
+
+function buildMockClient(overrides: Partial<AiServiceClient> = {}): AiServiceClient {
+  return {
+    waitForReady: vi.fn().mockResolvedValue(undefined),
+    getStartupInfo: vi.fn().mockResolvedValue({
+      version: '0.1.0',
+      modelFast: 'gpt-4o-mini',
+      modelStrong: 'claude-haiku-4-5',
+    }),
+    ...overrides,
+  } as unknown as AiServiceClient;
+}
+
+describe('StartupChecker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHasRanToday.mockResolvedValue(false);
+    mockFetchPrices.mockResolvedValue({
+      prices: [
+        { modelId: 'gpt-4o-mini', inputUsdPerToken: 0.00000015, outputUsdPerToken: 0.0000006 },
+        { modelId: 'claude-haiku-4-5', inputUsdPerToken: 0.000001, outputUsdPerToken: 0.000005 },
+      ],
+      cached: false,
+    });
+  });
+
+  it('skips startup when hasRanToday returns true', async () => {
+    mockHasRanToday.mockResolvedValueOnce(true);
+    const mockClient = buildMockClient();
+
+    const checker = new StartupChecker('/fake', mockClient);
+    const result = await checker.run(10);
+
+    expect(result.skipped).toBe(true);
+    expect(mockClient.waitForReady).not.toHaveBeenCalled();
+  });
+
+  it('does not call fetchPrices when skipped', async () => {
+    mockHasRanToday.mockResolvedValueOnce(true);
+    const mockClient = buildMockClient();
+
+    const checker = new StartupChecker('/fake', mockClient);
+    await checker.run(10);
+
+    expect(mockFetchPrices).not.toHaveBeenCalled();
+  });
+
+  it('returns full result when first run today', async () => {
+    const mockClient = buildMockClient();
+    const checker = new StartupChecker('/fake', mockClient);
+    const result = await checker.run(12);
+
+    expect(result.skipped).toBe(false);
+    expect(result.version).toBe('0.1.0');
+    expect(result.modelFast).toBe('gpt-4o-mini');
+    expect(result.modelStrong).toBe('claude-haiku-4-5');
+    expect(result.prices).toHaveLength(2);
+    expect(result.costEstimate.total).toBeGreaterThan(0);
+  });
+
+  it('reports pricesCached when PricingFetcher returns cached', async () => {
+    mockFetchPrices.mockResolvedValueOnce({
+      prices: [
+        { modelId: 'gpt-4o-mini', inputUsdPerToken: 0.00000015, outputUsdPerToken: 0.0000006 },
+      ],
+      cached: true,
+    });
+
+    const mockClient = buildMockClient();
+    const checker = new StartupChecker('/fake', mockClient);
+    const result = await checker.run(10);
+
+    expect(result.pricesCached).toBe(true);
+  });
+});

--- a/packages/core/src/cli/StartupChecker.ts
+++ b/packages/core/src/cli/StartupChecker.ts
@@ -1,0 +1,66 @@
+import type { AiServiceClient } from '../ai/AiServiceClient.js';
+import { PricingFetcher } from '../ai/PricingFetcher.js';
+import type { ModelPricing } from '../ai/PricingFetcher.js';
+import { estimateStartupCost } from '../domain/CostEstimator.js';
+import type { CostEstimate } from '../domain/CostEstimator.js';
+import { LastStartupStore } from './LastStartupStore.js';
+
+export interface StartupResult {
+  version: string;
+  modelFast: string;
+  modelStrong: string;
+  prices: ModelPricing[];
+  pricesCached: boolean;
+  costEstimate: CostEstimate;
+  skipped: boolean;
+}
+
+const EMPTY_COST: CostEstimate = { exploration: 0, generation: 0, total: 0 };
+
+export class StartupChecker {
+  constructor(
+    private readonly projectRoot: string,
+    private readonly aiClient: AiServiceClient,
+  ) {}
+
+  async run(estimatedActions: number): Promise<StartupResult> {
+    const store = new LastStartupStore(this.projectRoot);
+
+    if (await store.hasRanToday()) {
+      return {
+        version: '',
+        modelFast: '',
+        modelStrong: '',
+        prices: [],
+        pricesCached: false,
+        costEstimate: EMPTY_COST,
+        skipped: true,
+      };
+    }
+
+    await this.aiClient.waitForReady(3000);
+
+    const info = await this.aiClient.getStartupInfo();
+
+    const fetcher = new PricingFetcher(this.projectRoot);
+    const pricingResult = await fetcher.fetchPrices([info.modelFast, info.modelStrong]);
+
+    const fastPrice = pricingResult.prices.find((p) => p.modelId === info.modelFast);
+    const strongPrice = pricingResult.prices.find((p) => p.modelId === info.modelStrong);
+
+    const costEstimate = estimateStartupCost(estimatedActions, {
+      fast: fastPrice,
+      strong: strongPrice,
+    });
+
+    return {
+      version: info.version,
+      modelFast: info.modelFast,
+      modelStrong: info.modelStrong,
+      prices: pricingResult.prices,
+      pricesCached: pricingResult.cached,
+      costEstimate,
+      skipped: false,
+    };
+  }
+}

--- a/packages/core/src/cli/commands/generate.ts
+++ b/packages/core/src/cli/commands/generate.ts
@@ -75,8 +75,12 @@ async function generateAction(description: string, options: GenerateOptions): Pr
     // ── 1b. Startup check (cost estimate) ─────────────────────────────
     const startupChecker = new StartupChecker(process.cwd(), aiClient);
     const startupResult = await startupChecker.run(10);
-    // display and markRan are added in T24.5
-    void startupResult;
+    ui.renderStartupPanel(startupResult);
+    if (!startupResult.skipped) {
+      const { LastStartupStore } = await import('../LastStartupStore.js');
+      const lastStartupStore = new LastStartupStore(process.cwd());
+      await lastStartupStore.markRan();
+    }
 
     // ── 2. Session 0: parse input ─────────────────────────────────────
     const prepared = await aiClient.prepareInput({ rawInput: description });

--- a/packages/core/src/cli/commands/generate.ts
+++ b/packages/core/src/cli/commands/generate.ts
@@ -17,6 +17,7 @@ import { SetupManager } from '../../config/SetupManager.js';
 import { createAgentContext } from '../../domain/AgentContext.js';
 import { TestExecutor } from '../../executor/TestExecutor.js';
 import { SuiteManager } from '../../suite/SuiteManager.js';
+import { StartupChecker } from '../StartupChecker.js';
 import * as ui from '../ui/ProgressDisplay.js';
 
 // ── Types ─────────────────────────────────────────────────────────────
@@ -70,6 +71,12 @@ async function generateAction(description: string, options: GenerateOptions): Pr
     await pythonServer.start();
     const aiClient = new AiServiceClient(pythonServer.baseUrl);
     ui.success('AI Service ready');
+
+    // ── 1b. Startup check (cost estimate) ─────────────────────────────
+    const startupChecker = new StartupChecker(process.cwd(), aiClient);
+    const startupResult = await startupChecker.run(10);
+    // display and markRan are added in T24.5
+    void startupResult;
 
     // ── 2. Session 0: parse input ─────────────────────────────────────
     const prepared = await aiClient.prepareInput({ rawInput: description });

--- a/packages/core/src/cli/ui/ProgressDisplay.test.ts
+++ b/packages/core/src/cli/ui/ProgressDisplay.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { StartupResult } from '../StartupChecker.js';
+import { renderStartupPanel } from './ProgressDisplay.js';
+
+// Capture console output
+let consoleOutput: string[];
+const originalLog = console.log;
+const originalError = console.error;
+
+beforeEach(() => {
+  consoleOutput = [];
+  console.log = (...args: unknown[]) => {
+    consoleOutput.push(args.map(String).join(' '));
+  };
+  console.error = (...args: unknown[]) => {
+    consoleOutput.push(args.map(String).join(' '));
+  };
+});
+
+afterEach(() => {
+  console.log = originalLog;
+  console.error = originalError;
+  vi.unstubAllEnvs();
+});
+
+function buildResult(overrides: Partial<StartupResult> = {}): StartupResult {
+  return {
+    version: '0.1.0',
+    modelFast: 'gpt-4o-mini',
+    modelStrong: 'claude-haiku-4-5',
+    prices: [
+      { modelId: 'gpt-4o-mini', inputUsdPerToken: 0.00000015, outputUsdPerToken: 0.0000006 },
+      { modelId: 'claude-haiku-4-5', inputUsdPerToken: 0.000001, outputUsdPerToken: 0.000005 },
+    ],
+    pricesCached: false,
+    costEstimate: { exploration: 0.01, generation: 0.08, total: 0.09 },
+    skipped: false,
+    ...overrides,
+  };
+}
+
+describe('renderStartupPanel', () => {
+  it('renders nothing when result is skipped', () => {
+    renderStartupPanel(buildResult({ skipped: true }));
+    expect(consoleOutput).toHaveLength(0);
+  });
+
+  it('renders version in header', () => {
+    renderStartupPanel(buildResult());
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('0.1.0');
+  });
+
+  it('renders model prices', () => {
+    renderStartupPanel(buildResult());
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('gpt-4o-mini');
+    expect(joined).toContain('claude-haiku-4-5');
+  });
+
+  it('renders cost estimate with total', () => {
+    renderStartupPanel(buildResult());
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('Exploration');
+    expect(joined).toContain('Generation');
+    expect(joined).toContain('Total estimated');
+  });
+
+  it('shows (cached) suffix when pricesCached is true', () => {
+    renderStartupPanel(buildResult({ pricesCached: true }));
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('cached');
+  });
+
+  it('does not show (cached) suffix when pricesCached is false', () => {
+    renderStartupPanel(buildResult({ pricesCached: false }));
+    const joined = consoleOutput.join('\n');
+    // The word "cached" should not appear (excluding any other context)
+    expect(joined).not.toContain('cached');
+  });
+
+  it('never renders API key values', () => {
+    const dummyKey = 'sk-SUPERSECRETKEY12345';
+    vi.stubEnv('OPENAI_API_KEY', dummyKey);
+    vi.stubEnv('ANTHROPIC_API_KEY', dummyKey);
+
+    renderStartupPanel(buildResult());
+    const joined = consoleOutput.join('\n');
+    expect(joined).not.toContain(dummyKey);
+    expect(joined).toContain('configured');
+  });
+
+  it('shows not set when API keys are missing', () => {
+    delete process.env['OPENAI_API_KEY'];
+    delete process.env['ANTHROPIC_API_KEY'];
+
+    renderStartupPanel(buildResult());
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('not set');
+  });
+
+  it('shows prices unavailable when prices array is empty', () => {
+    renderStartupPanel(buildResult({ prices: [] }));
+    const joined = consoleOutput.join('\n');
+    expect(joined).toContain('prices unavailable');
+  });
+});

--- a/packages/core/src/cli/ui/ProgressDisplay.test.ts
+++ b/packages/core/src/cli/ui/ProgressDisplay.test.ts
@@ -10,10 +10,10 @@ const originalError = console.error;
 
 beforeEach(() => {
   consoleOutput = [];
-  console.log = (...args: unknown[]) => {
+  console.log = (...args: unknown[]): void => {
     consoleOutput.push(args.map(String).join(' '));
   };
-  console.error = (...args: unknown[]) => {
+  console.error = (...args: unknown[]): void => {
     consoleOutput.push(args.map(String).join(' '));
   };
 });

--- a/packages/core/src/cli/ui/ProgressDisplay.ts
+++ b/packages/core/src/cli/ui/ProgressDisplay.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk';
 
+import type { StartupResult } from '../StartupChecker.js';
+
 // ── Basic UI ──────────────────────────────────────────────────────────
 
 export function header(title: string): void {
@@ -35,6 +37,51 @@ export function listItem(label: string, value: string): void {
 
 export function blank(): void {
   console.log();
+}
+
+// ── Startup panel ────────────────────────────────────────────────────
+
+function formatPricePerMTok(usdPerToken: number): string {
+  const perMTok = usdPerToken * 1_000_000;
+  return `$${perMTok.toFixed(2)}`;
+}
+
+function keyStatus(envVar: string): string {
+  return process.env[envVar]
+    ? chalk.green('configured')
+    : chalk.red('not set');
+}
+
+export function renderStartupPanel(result: StartupResult): void {
+  if (result.skipped) {
+    return;
+  }
+
+  const cachedSuffix = result.pricesCached ? chalk.dim(' (cached)') : '';
+
+  header(`playwright-ppia v${result.version}`);
+
+  subheader('API Keys');
+  listItem('OpenAI API key', keyStatus('OPENAI_API_KEY'));
+  listItem('Anthropic key', keyStatus('ANTHROPIC_API_KEY'));
+
+  subheader(`Prices${cachedSuffix}`);
+  for (const price of result.prices) {
+    const inputStr = formatPricePerMTok(price.inputUsdPerToken);
+    const outputStr = formatPricePerMTok(price.outputUsdPerToken);
+    success(`${price.modelId.padEnd(20)} ${inputStr} / ${outputStr} MTok`);
+  }
+  if (result.prices.length === 0) {
+    warn('prices unavailable');
+  }
+
+  subheader('Cost estimate');
+  const est = result.costEstimate;
+  listItem('Exploration', `${result.modelFast.padEnd(20)} ${formatCost(est.exploration)}`);
+  listItem('Generation', `${result.modelStrong.padEnd(20)} ${formatCost(est.generation)}`);
+  separator();
+  listItem('Total estimated', `${''.padEnd(20)} ${formatCost(est.total)}`);
+  blank();
 }
 
 // ── Cost estimation ───────────────────────────────────────────────────

--- a/packages/core/src/domain/CostEstimator.ts
+++ b/packages/core/src/domain/CostEstimator.ts
@@ -1,0 +1,29 @@
+import type { ModelPricing } from '../ai/PricingFetcher.js';
+
+const AVG_TOKENS_PER_ACTION = 2_500;
+const AVG_TOKENS_GENERATION = 8_000;
+
+export interface CostEstimate {
+  exploration: number;
+  generation: number;
+  total: number;
+}
+
+export function estimateStartupCost(
+  estimatedActions: number,
+  prices: { fast: ModelPricing | undefined; strong: ModelPricing | undefined },
+): CostEstimate {
+  const exploration = prices.fast
+    ? estimatedActions * AVG_TOKENS_PER_ACTION * prices.fast.inputUsdPerToken
+    : 0;
+
+  const generation = prices.strong
+    ? AVG_TOKENS_GENERATION * prices.strong.inputUsdPerToken
+    : 0;
+
+  return {
+    exploration,
+    generation,
+    total: exploration + generation,
+  };
+}


### PR DESCRIPTION
## Summary

- **T24.1** — Python: `/startup-info` endpoint + health hardening (ping disponible antes del init lento)
- **T24.2** — Python: pricing port (hexagonal), domain model `ModelPrice`, OpenRouter adapter con atomic cache write
- **T24.3** — Python: cost estimator use case + token budget constants; `estimated_cost` en `PrepareInputResponse`
- **T24.4** — TypeScript: `StartupChecker`, `PricingFetcher` (daily cache), `CostEstimator`, `LastStartupStore`
- **T24.5** — TypeScript: `renderStartupPanel` + once-per-day gate + `markRan()` en `ppia generate`

## Test plan

- [ ] `pnpm lint` ✅
- [ ] `pnpm typecheck` ✅
- [ ] `pnpm test` — 154/154 ✅
- [ ] `ruff check` ✅
- [ ] `mypy --strict` ✅
- [ ] `pytest` — 63/63 ✅
- [ ] Pre-push hook pasó en verde

Closes #24